### PR TITLE
Make Chapters in MangaSearchEntry a nullable property

### DIFF
--- a/JikanDotNet/Model/Search/MangaSearchEntry.cs
+++ b/JikanDotNet/Model/Search/MangaSearchEntry.cs
@@ -84,6 +84,6 @@ namespace JikanDotNet
 		/// Number of published chapters.
 		/// </summary>
 		[JsonProperty(PropertyName = "chapters")]
-		public int Chapters { get; set; }
+		public int? Chapters { get; set; }
 	}
 }


### PR DESCRIPTION
API response for chapters can be null. Fixes #15 