### PR TITLE
Fix requesting for users list with list type and page

### DIFF
--- a/JikanDotNet.Test/UserAnimeListTests.cs
+++ b/JikanDotNet.Test/UserAnimeListTests.cs
@@ -87,6 +87,21 @@ namespace JikanDotNet.Tests
 			}
 		}
 
+		[Fact]
+		public async Task GetUserAnimeList_ErvelanCompleted_ShouldParseErvelanAnimeCompletedListWithPage()
+		{
+			// When
+			var animeList = await _jikan.GetUserAnimeList("Ervelan", UserAnimeListExtension.Completed, 1);
+
+			// Then
+			using (new AssertionScope())
+			{
+				animeList.Should().NotBeNull();
+				animeList.Anime.First().WatchingStatus.Should().Be(UserAnimeListExtension.Completed);
+				animeList.Anime.First().AiringStatus.Should().Be(AiringStatus.Completed);
+			}
+		}
+
 		[Theory]
 		[InlineData(null)]
 		[InlineData("")]

--- a/JikanDotNet.Test/UserMangaListTests.cs
+++ b/JikanDotNet.Test/UserMangaListTests.cs
@@ -75,6 +75,21 @@ namespace JikanDotNet.Tests
 		}
 
 		[Fact]
+		public async Task GetUserMangaList_ErvelanCompleted_ShouldParseErvelanMangaCompletedList()
+		{
+			// When
+			var mangalist = await this._jikan.GetUserMangaList("Ervelan", UserMangaListExtension.Completed, 1);
+
+			// Then
+			using (new AssertionScope())
+			{
+				mangalist.Should().NotBeNull();
+				mangalist.Manga.First().ReadingStatus.Should().Be(UserMangaListExtension.Completed);
+				mangalist.Manga.First().PublishingStatus.Should().Be(AiringStatus.Completed);
+			}
+		}
+
+		[Fact]
 		public async Task GetUserMangaList_ErvelanDropped_ShouldParseErvelanMangaDroppedList()
 		{
 			// When

--- a/JikanDotNet/Jikan.cs
+++ b/JikanDotNet/Jikan.cs
@@ -1142,8 +1142,7 @@ namespace JikanDotNet
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
-			var query = string.Concat(UserExtension.AnimeList.GetDescription(), filter.GetDescription());
-			string[] endpointParts = new string[] { JikanEndPointCategories.User, username, query, page.ToString() };
+			string[] endpointParts = new string[] { JikanEndPointCategories.User, username, UserExtension.AnimeList.GetDescription(), filter.GetDescription(), page.ToString() };
 			return await ExecuteGetRequest<UserAnimeList>(endpointParts);
 		}
 
@@ -1216,8 +1215,7 @@ namespace JikanDotNet
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
-			var query = string.Concat(UserExtension.MangaList.GetDescription(), filter.GetDescription());
-			string[] endpointParts = new string[] { JikanEndPointCategories.User, username, query, page.ToString() };
+			string[] endpointParts = new string[] { JikanEndPointCategories.User, username, UserExtension.MangaList.GetDescription(), filter.GetDescription(), page.ToString() };
 			return await ExecuteGetRequest<UserMangaList>(endpointParts);
 		}
 


### PR DESCRIPTION
Currently when requesting user's lists while specifying status and page it gets concatenated in something like this `Ervelan/animelistcompleted/1` while correct query should look like this `Ervelan/animelist/completed/1`.
This pull request fixes this.
As proof that issue exist you can checkout d4f6bb8 and run new tests to see them failing. Then you can checkout 85bf580 and see that tests are running successfully.