### PR TITLE
[Fix] Don't pass page parameter to query string twice in `SearchManga`

### DIFF
--- a/JikanDotNet/Jikan.cs
+++ b/JikanDotNet/Jikan.cs
@@ -1498,7 +1498,7 @@ namespace JikanDotNet
 			Guard.IsGreaterThanZero(page, nameof(page));
 			Guard.IsNotNull(searchConfig, nameof(searchConfig));
 			query = string.Concat(JikanEndPointCategories.Manga, "/", page.ToString(), "?q=", query.Replace(' ', '+'), "&", searchConfig.ConfigToString());
-			string[] endpointParts = new string[] { JikanEndPointCategories.Search, query, page.ToString() };
+			string[] endpointParts = new string[] { JikanEndPointCategories.Search, query};
 			return await ExecuteGetRequest<MangaSearchResult>(endpointParts);
 		}
 


### PR DESCRIPTION
Current implementation of [`SearchManga(string query, int page, MangaSearchConfig searchConfig)`](https://github.com/Ervie/jikan.net/blob/fb9c76feeca9eb787b1e097215d5a7128be4d2bb/JikanDotNet/Jikan.cs#L1495) uses page parameter twice, it returns correct result, but it's pretty pointless so it should be removed in my opinion.