### PR TITLE
Validate enums

### DIFF
--- a/JikanDotNet.Test/AnimeSearchTests.cs
+++ b/JikanDotNet.Test/AnimeSearchTests.cs
@@ -359,6 +359,41 @@ namespace JikanDotNet.Tests
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();
 		}
 
+		[Theory]
+		[InlineData((AiringStatus)int.MaxValue, null, null, null, null, null)]
+		[InlineData((AiringStatus)int.MinValue, null, null, null, null, null)]
+		[InlineData(null, (AgeRating)int.MaxValue, null, null, null, null)]
+		[InlineData(null, (AgeRating)int.MinValue, null, null, null, null)]
+		[InlineData(null, null, (AnimeType)int.MaxValue, null, null, null)]
+		[InlineData(null, null, (AnimeType)int.MinValue, null, null, null)]
+		[InlineData(null, null, null, (AnimeSearchSortable)int.MaxValue, null, null)]
+		[InlineData(null, null, null, (AnimeSearchSortable)int.MinValue, null, null)]
+		[InlineData(null, null, null, AnimeSearchSortable.Episodes, (SortDirection)int.MaxValue, null)]
+		[InlineData(null, null, null, AnimeSearchSortable.Episodes, (SortDirection)int.MinValue, null)]
+		[InlineData(null, null, null, null, null, (GenreSearch)int.MaxValue)]
+		[InlineData(null, null, null, null, null, (GenreSearch)int.MinValue)]
+		public async Task SearchManga_EmptyQueryWithConfigWithInvalidEnums_ShouldThrowValidationException(
+			AiringStatus? airingStatus, AgeRating? rating, AnimeType? mangaType, AnimeSearchSortable? orderBy, SortDirection? sortDirection,
+			GenreSearch? genreSearch)
+		{
+			// Given
+			var searchConfig = new AnimeSearchConfig()
+			{
+				Status = airingStatus.GetValueOrDefault(),
+				Rating = rating.GetValueOrDefault(),
+				Type = mangaType.GetValueOrDefault(),
+				OrderBy = orderBy.GetValueOrDefault(),
+				SortDirection = sortDirection.GetValueOrDefault(),
+				Genres = genreSearch.HasValue ? new []{ genreSearch.Value} : Array.Empty<GenreSearch>()
+			};
+
+			// When
+			Func<Task<AnimeSearchResult>> func = _jikan.Awaiting(x => x.SearchAnime(searchConfig));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 		[Fact]
 		public async Task SearchAnime_EmptyQueryActionTvAnime_ShouldFindAfroSamuraiAndAjin()
 		{

--- a/JikanDotNet.Test/GenreTests.cs
+++ b/JikanDotNet.Test/GenreTests.cs
@@ -62,6 +62,18 @@ namespace JikanDotNet.Tests
 			}
 		}
 
+		[Theory]
+		[InlineData((GenreSearch) int.MaxValue)]
+		[InlineData((GenreSearch) int.MinValue)]
+		public async Task GetAnimeGenre_InvalidGenre_ShouldThrowValidationException(GenreSearch genreSearch)
+		{
+			// When
+			Func<Task<AnimeGenre>> func = this._jikan.Awaiting(x=> x.GetAnimeGenre(genreSearch));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 		[Fact]
 		public async Task GetAnimeGenre_MechaGenreId_ShouldParseAnimeMechaGenre()
 		{
@@ -118,6 +130,19 @@ namespace JikanDotNet.Tests
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();
 		}
 
+		[Theory]
+		[InlineData((GenreSearch)int.MinValue)]
+		[InlineData((GenreSearch) int.MaxValue)]
+		public async Task GetAnimeGenre_InvalidGenreValidPage_ShouldThrowValidationException(GenreSearch genreSearch)
+		{
+			// When
+			Func<Task<AnimeGenre>> func = _jikan.Awaiting(x => x.
+				GetAnimeGenre(genreSearch, 1));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 		[Fact]
 		public async Task GetAnimeGenre_MysteryGenreIdSecondPage_ShouldParseAnimeMysteryGenreMetadata()
 		{
@@ -162,6 +187,19 @@ namespace JikanDotNet.Tests
 			// Then
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();
 		}
+
+		[Theory]
+		[InlineData((GenreSearch) int.MaxValue)]
+		[InlineData((GenreSearch) int.MinValue)]
+		public async Task GetMangaGenre_InvalidGenre_ShouldThrowValidationException(GenreSearch genreSearch)
+		{
+			// When
+			Func<Task<MangaGenre>> func = this._jikan.Awaiting(x=> x.GetMangaGenre(genreSearch));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 
 		[Fact]
 		public async Task GetMangaGenre_ActionGenreId_ShouldParseMangaActionGenre()
@@ -230,6 +268,19 @@ namespace JikanDotNet.Tests
 		{
 			// When
 			Func<Task<MangaGenre>> func = _jikan.Awaiting(x => x.GetMangaGenre(GenreSearch.Mystery, page));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
+		[Theory]
+		[InlineData((GenreSearch)int.MinValue)]
+		[InlineData((GenreSearch) int.MaxValue)]
+		public async Task GetMangaGenre_InvalidGenreValidPage_ShouldThrowValidationException(GenreSearch genreSearch)
+		{
+			// When
+			Func<Task<MangaGenre>> func = _jikan.Awaiting(x => x.
+				GetMangaGenre(genreSearch, 1));
 
 			// Then
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();

--- a/JikanDotNet.Test/MangaSearchTests.cs
+++ b/JikanDotNet.Test/MangaSearchTests.cs
@@ -342,6 +342,41 @@ namespace JikanDotNet.Tests
 			}
 		}
 
+		[Theory]
+		[InlineData((AiringStatus)int.MaxValue, null, null, null, null, null)]
+		[InlineData((AiringStatus)int.MinValue, null, null, null, null, null)]
+		[InlineData(null, (AgeRating)int.MaxValue, null, null, null, null)]
+		[InlineData(null, (AgeRating)int.MinValue, null, null, null, null)]
+		[InlineData(null, null, (MangaType)int.MaxValue, null, null, null)]
+		[InlineData(null, null, (MangaType)int.MinValue, null, null, null)]
+		[InlineData(null, null, null, (MangaSearchSortable)int.MaxValue, null, null)]
+		[InlineData(null, null, null, (MangaSearchSortable)int.MinValue, null, null)]
+		[InlineData(null, null, null, MangaSearchSortable.Chapters, (SortDirection)int.MaxValue, null)]
+		[InlineData(null, null, null, MangaSearchSortable.Chapters, (SortDirection)int.MinValue, null)]
+		[InlineData(null, null, null, null, null, (GenreSearch)int.MaxValue)]
+		[InlineData(null, null, null, null, null, (GenreSearch)int.MinValue)]
+		public async Task SearchManga_EmptyQueryWithConfigWithInvalidEnums_ShouldThrowValidationException(
+			AiringStatus? airingStatus, AgeRating? rating, MangaType? mangaType, MangaSearchSortable? orderBy, SortDirection? sortDirection,
+			GenreSearch? genreSearch)
+		{
+			// Given
+			var searchConfig = new MangaSearchConfig()
+			{
+				Status = airingStatus.GetValueOrDefault(),
+				Rating = rating.GetValueOrDefault(),
+				Type = mangaType.GetValueOrDefault(),
+				OrderBy = orderBy.GetValueOrDefault(),
+				SortDirection = sortDirection.GetValueOrDefault(),
+				Genres = genreSearch.HasValue ? new []{ genreSearch.Value} : Array.Empty<GenreSearch>()
+			};
+
+			// When
+			Func<Task<MangaSearchResult>> func = _jikan.Awaiting(x => x.SearchManga(searchConfig));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 		[Fact]
 		public async Task SearchManga_EmptyQueryActionManga_ShouldFindCrowAnd007()
 		{

--- a/JikanDotNet.Test/ScheduleTests.cs
+++ b/JikanDotNet.Test/ScheduleTests.cs
@@ -1,7 +1,9 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using FluentAssertions.Execution;
 using System.Linq;
 using System.Threading.Tasks;
+using JikanDotNet.Exceptions;
 using Xunit;
 
 namespace JikanDotNet.Tests
@@ -69,5 +71,18 @@ namespace JikanDotNet.Tests
 				unknownScheduleTitles.Should().Contain("Jinxiu Shenzhou Zhi Qi You Ji");
 			}
 		}
+
+		[Theory]
+		[InlineData((ScheduledDay) int.MaxValue)]
+		[InlineData((ScheduledDay) int.MinValue)]
+		public async Task GetSchedule_InvalidScheduledDay_ShouldThrowValidationException(ScheduledDay schedule)
+		{
+			// When
+			Func<Task<Schedule>> func = this._jikan.Awaiting(x=> x.GetSchedule(schedule));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 	}
 }

--- a/JikanDotNet.Test/SeasonTests.cs
+++ b/JikanDotNet.Test/SeasonTests.cs
@@ -36,6 +36,18 @@ namespace JikanDotNet.Tests
 		}
 
 		[Theory]
+		[InlineData((Seasons) int.MaxValue)]
+		[InlineData((Seasons) int.MinValue)]
+		public async Task GetSeasons_InvalidSeasonValidYear_ShouldThrowValidationException(Seasons seasons)
+		{
+			// When
+			Func<Task<Season>> func = this._jikan.Awaiting(x=> x.GetSeason(2021,seasons));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
+		[Theory]
 		[InlineData(1000)]
 		[InlineData(1900)]
 		[InlineData(2100)]

--- a/JikanDotNet.Test/TopTests.cs
+++ b/JikanDotNet.Test/TopTests.cs
@@ -71,6 +71,18 @@ namespace JikanDotNet.Tests
 		}
 
 		[Theory]
+		[InlineData((TopAnimeExtension) int.MaxValue)]
+		[InlineData((TopAnimeExtension) int.MinValue)]
+		public async Task GetAnimeTop_InvalidType_ShouldThrowValidationException(TopAnimeExtension topAnimeExtension)
+		{
+			// When
+			Func<Task<AnimeTop>> func = this._jikan.Awaiting(x=> x.GetAnimeTop(topAnimeExtension));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
+		[Theory]
 		[InlineData(int.MinValue)]
 		[InlineData(-1)]
 		[InlineData(0)]
@@ -78,6 +90,18 @@ namespace JikanDotNet.Tests
 		{
 			// When
 			Func<Task<AnimeTop>> func = _jikan.Awaiting(x => x.GetAnimeTop(page, TopAnimeExtension.TopAiring));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
+		[Theory]
+		[InlineData((TopAnimeExtension) int.MaxValue)]
+		[InlineData((TopAnimeExtension) int.MinValue)]
+		public async Task GetAnimeTop_InvalidTypeValidPage_ShouldThrowValidationException(TopAnimeExtension topAnimeExtension)
+		{
+			// When
+			Func<Task<AnimeTop>> func = this._jikan.Awaiting(x=> x.GetAnimeTop(1, topAnimeExtension));
 
 			// Then
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();
@@ -182,6 +206,18 @@ namespace JikanDotNet.Tests
 		}
 
 		[Theory]
+		[InlineData((TopMangaExtension)int.MinValue)]
+		[InlineData((TopMangaExtension)int.MaxValue)]
+		public async Task GetMangaTop_InvalidType_ShouldThrowValidationException(TopMangaExtension topMangaExtension)
+		{
+			// When
+			Func<Task<MangaTop>> func = _jikan.Awaiting(x => x.GetMangaTop(topMangaExtension));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
+		[Theory]
 		[InlineData(int.MinValue)]
 		[InlineData(-1)]
 		[InlineData(0)]
@@ -189,6 +225,18 @@ namespace JikanDotNet.Tests
 		{
 			// When
 			Func<Task<MangaTop>> func = _jikan.Awaiting(x => x.GetMangaTop(page, TopMangaExtension.TopPopularity));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
+		[Theory]
+		[InlineData((TopMangaExtension)int.MinValue)]
+		[InlineData((TopMangaExtension)int.MaxValue)]
+		public async Task GetMangaTop_InvalidTypeValidPage_ShouldThrowValidationException(TopMangaExtension topMangaExtension)
+		{
+			// When
+			Func<Task<MangaTop>> func = _jikan.Awaiting(x => x.GetMangaTop(1, topMangaExtension));
 
 			// Then
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();

--- a/JikanDotNet.Test/UserAnimeListTests.cs
+++ b/JikanDotNet.Test/UserAnimeListTests.cs
@@ -58,6 +58,30 @@ namespace JikanDotNet.Tests
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();
 		}
 
+		[Theory]
+		[InlineData((UserAnimeListExtension)int.MaxValue)]
+		[InlineData((UserAnimeListExtension)int.MinValue)]
+		public async Task GetUserAnimeList_ErvelanWithInvalidExtension_ShouldThrowValidationException(UserAnimeListExtension userAnimeListExtension)
+		{
+			// When
+			Func<Task<UserAnimeList>> func = _jikan.Awaiting(x => x.GetUserAnimeList("Ervelan", userAnimeListExtension));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
+		[Theory]
+		[InlineData((UserAnimeListExtension)int.MaxValue)]
+		[InlineData((UserAnimeListExtension)int.MinValue)]
+		public async Task GetUserAnimeList_ErvelanWithValidPageWithInvalidExtension_ShouldThrowValidationException(UserAnimeListExtension userAnimeListExtension)
+		{
+			// When
+			Func<Task<UserAnimeList>> func = _jikan.Awaiting(x => x.GetUserAnimeList("Ervelan", userAnimeListExtension, 1));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 		[Fact]
 		public async Task GetUserAnimeList_ErvelanWatching_ShouldParseErvelanAnimeWatchingList()
 		{

--- a/JikanDotNet.Test/UserAnimeListTests.cs
+++ b/JikanDotNet.Test/UserAnimeListTests.cs
@@ -200,6 +200,39 @@ namespace JikanDotNet.Tests
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();
 		}
 
+		[Theory]
+		[InlineData((Seasons)int.MaxValue, null, null, null, null)]
+		[InlineData((Seasons)int.MinValue, null, null, null, null)]
+		[InlineData(null, (UserListAnimeAiringStatus)int.MaxValue, null, null, null)]
+		[InlineData(null, (UserListAnimeAiringStatus)int.MinValue, null, null, null)]
+		[InlineData(null, null, (UserListAnimeSearchSortable)int.MaxValue, null, null)]
+		[InlineData(null, null, (UserListAnimeSearchSortable)int.MinValue, null, null)]
+		[InlineData(null, null, UserListAnimeSearchSortable.Priority, (UserListAnimeSearchSortable)int.MaxValue, null)]
+		[InlineData(null, null, UserListAnimeSearchSortable.Priority, (UserListAnimeSearchSortable)int.MinValue, null)]
+		[InlineData(null, null, UserListAnimeSearchSortable.Priority, null, (SortDirection)int.MaxValue)]
+		[InlineData(null, null, UserListAnimeSearchSortable.Priority, null, (SortDirection)int.MinValue)]
+		public async Task GetUserAnimeList_ErvelanWithConfigWithInvalidEnums_ShouldThrowValidationException(
+			Seasons? season, UserListAnimeAiringStatus? airingStatus, UserListAnimeSearchSortable? orderBy, UserListAnimeSearchSortable? orderBy2,
+			SortDirection? sortDirection)
+		{
+			// Given
+			var searchConfig = new UserListAnimeSearchConfig()
+			{
+				Year = season.HasValue ? 2021 : default,
+				Season = season.GetValueOrDefault(),
+				AiringStatus = airingStatus.GetValueOrDefault(),
+				OrderBy = orderBy.GetValueOrDefault(),
+				OrderBy2 = orderBy2.GetValueOrDefault(),
+				SortDirection = sortDirection.GetValueOrDefault()
+			};
+
+			// When
+			Func<Task<UserAnimeList>> func = _jikan.Awaiting(x => x.GetUserAnimeList("Ervelan", searchConfig));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 		[Fact]
 		public async Task GetUserAnimeList_NullSearchConfig_ShouldFindDNandDP()
 		{

--- a/JikanDotNet.Test/UserMangaListTests.cs
+++ b/JikanDotNet.Test/UserMangaListTests.cs
@@ -58,6 +58,29 @@ namespace JikanDotNet.Tests
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();
 		}
 
+		[Theory]
+		[InlineData((UserMangaListExtension)int.MaxValue)]
+		[InlineData((UserMangaListExtension)int.MinValue)]
+		public async Task GetUserMangaList_ErvelanWithInvalidExtension_ShouldThrowValidationException(UserMangaListExtension userMangaListExtension)
+		{
+			// When
+			Func<Task<UserMangaList>> func = _jikan.Awaiting(x => x.GetUserMangaList("Ervelan", userMangaListExtension));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
+		[Theory]
+		[InlineData((UserMangaListExtension)int.MaxValue)]
+		[InlineData((UserMangaListExtension)int.MinValue)]
+		public async Task GetUserMangaList_ErvelanWithValidPageWithInvalidExtension_ShouldThrowValidationException(UserMangaListExtension userMangaListExtension)
+		{
+			// When
+			Func<Task<UserMangaList>> func = _jikan.Awaiting(x => x.GetUserMangaList("Ervelan", userMangaListExtension, 1));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
 		[Fact]
 		public async Task GetUserMangaList_ErvelanReading_ShouldParseErvelanMangaReadingList()
 		{

--- a/JikanDotNet.Test/UserMangaListTests.cs
+++ b/JikanDotNet.Test/UserMangaListTests.cs
@@ -171,6 +171,35 @@ namespace JikanDotNet.Tests
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();
 		}
 
+		[Theory]
+		[InlineData((UserListMangaPublishingStatus)int.MaxValue, null, null, null)]
+		[InlineData((UserListMangaPublishingStatus)int.MinValue, null, null, null)]
+		[InlineData(null, (UserListMangaSearchSortable)int.MaxValue, null, null)]
+		[InlineData(null, (UserListMangaSearchSortable)int.MinValue, null, null)]
+		[InlineData(null, UserListMangaSearchSortable.Priority, (UserListMangaSearchSortable)int.MaxValue, null)]
+		[InlineData(null, UserListMangaSearchSortable.Priority, (UserListMangaSearchSortable)int.MinValue, null)]
+		[InlineData(null, UserListMangaSearchSortable.Priority, null, (SortDirection)int.MaxValue)]
+		[InlineData(null, UserListMangaSearchSortable.Priority, null, (SortDirection)int.MinValue)]
+		public async Task GetUserMangaList_ErvelanWithConfigWithInvalidEnums_ShouldThrowValidationException(
+			UserListMangaPublishingStatus? publishingStatus, UserListMangaSearchSortable? orderBy, UserListMangaSearchSortable? orderBy2,
+			SortDirection? sortDirection)
+		{
+			// Given
+			var searchConfig = new UserListMangaSearchConfig()
+			{
+				PublishingStatus = publishingStatus.GetValueOrDefault(),
+				OrderBy = orderBy.GetValueOrDefault(),
+				OrderBy2 = orderBy2.GetValueOrDefault(),
+				SortDirection = sortDirection.GetValueOrDefault()
+			};
+
+			// When
+			Func<Task<UserMangaList>> func = _jikan.Awaiting(x => x.GetUserMangaList("Ervelan", searchConfig));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 		[Fact]
 		public async Task GetUserMangaList_ValidUsernameNullConfig_ShouldThrowValidationException()
 		{

--- a/JikanDotNet.Test/UserTests.cs
+++ b/JikanDotNet.Test/UserTests.cs
@@ -107,6 +107,18 @@ namespace JikanDotNet.Tests
 			await func.Should().ThrowExactlyAsync<JikanValidationException>();
 		}
 
+		[Theory]
+		[InlineData((UserHistoryExtension)int.MaxValue)]
+		[InlineData((UserHistoryExtension)int.MinValue)]
+		public async Task GetUserHistory_ErvelanWithInvalidExtension_ShouldThrowValidationException(UserHistoryExtension userHistoryExtension)
+		{
+			// When
+			Func<Task<UserHistory>> func = _jikan.Awaiting(x => x.GetUserHistory("Ervelan", userHistoryExtension));
+
+			// Then
+			await func.Should().ThrowExactlyAsync<JikanValidationException>();
+		}
+
 		[Fact]
 		public async Task GetUserHistory_ErvelanMangaHistory_ShouldParseErvelanMangaHistory()
 		{

--- a/JikanDotNet/Helpers/Guard.cs
+++ b/JikanDotNet/Helpers/Guard.cs
@@ -51,5 +51,13 @@ namespace JikanDotNet.Helpers
 
 			throw new JikanValidationException(message, argumentName);
 		}
+
+		internal static void IsValidEnum<TEnum>(TEnum arg, string argumentName) where TEnum : struct, Enum
+		{
+			if (!Enum.IsDefined(typeof(TEnum), arg))
+			{
+				throw new JikanValidationException("Enum value must be valid", argumentName);
+			}
+		}
 	}
 }

--- a/JikanDotNet/Jikan.cs
+++ b/JikanDotNet/Jikan.cs
@@ -206,6 +206,7 @@ namespace JikanDotNet
 		/// <returns>Information about anime genre</returns>
 		public async Task<AnimeGenre> GetAnimeGenre(GenreSearch genre)
 		{
+			Guard.IsValidEnum(genre, nameof(genre));
 			string[] endpointParts = new string[] { JikanEndPointCategories.Genre, JikanEndPointCategories.Anime, genre.GetDescription() };
 			return await ExecuteGetRequest<AnimeGenre>(endpointParts);
 		}
@@ -233,6 +234,7 @@ namespace JikanDotNet
 		public async Task<AnimeGenre> GetAnimeGenre(GenreSearch genre, int page)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
+			Guard.IsValidEnum(genre, nameof(genre));
 			string[] endpointParts = new string[] { JikanEndPointCategories.Genre, JikanEndPointCategories.Anime, genre.GetDescription(), page.ToString() };
 			return await ExecuteGetRequest<AnimeGenre>(endpointParts);
 		}
@@ -520,6 +522,7 @@ namespace JikanDotNet
 		/// <returns>Information about manga genre</returns>
 		public async Task<MangaGenre> GetMangaGenre(GenreSearch genre)
 		{
+			Guard.IsValidEnum(genre, nameof(genre));
 			string[] endpointParts = new string[] { JikanEndPointCategories.Genre, JikanEndPointCategories.Manga, genre.GetDescription() };
 			return await ExecuteGetRequest<MangaGenre>(endpointParts);
 		}
@@ -547,6 +550,7 @@ namespace JikanDotNet
 		public async Task<MangaGenre> GetMangaGenre(GenreSearch genre, int page)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
+			Guard.IsValidEnum(genre, nameof(genre));
 			string[] endpointParts = new string[] { JikanEndPointCategories.Genre, JikanEndPointCategories.Manga, genre.GetDescription(), page.ToString() };
 			return await ExecuteGetRequest<MangaGenre>(endpointParts);
 		}
@@ -752,6 +756,7 @@ namespace JikanDotNet
 		/// <returns>Current season schedule.</returns>
 		public async Task<Schedule> GetSchedule(ScheduledDay scheduledDay)
 		{
+			Guard.IsValidEnum(scheduledDay, nameof(scheduledDay));
 			string[] endpointParts = new string[] { JikanEndPointCategories.Schedule, scheduledDay.GetDescription() };
 			return await ExecuteGetRequest<Schedule>(endpointParts);
 		}
@@ -783,6 +788,7 @@ namespace JikanDotNet
 		public async Task<Season> GetSeason(int year, Seasons season)
 		{
 			Guard.IsValid(year => year >= 1000 && year < 10000, year, nameof(year));
+			Guard.IsValidEnum(season, nameof(season));
 			string[] endpointParts = new string[] { JikanEndPointCategories.Season, year.ToString(), season.GetDescription() };
 			return await ExecuteGetRequest<Season>(endpointParts);
 		}
@@ -852,6 +858,7 @@ namespace JikanDotNet
 		/// <returns>List of top anime.</returns>
 		public async Task<AnimeTop> GetAnimeTop(TopAnimeExtension extension)
 		{
+			Guard.IsValidEnum(extension, nameof(extension));
 			string[] endpointParts = new string[] { JikanEndPointCategories.TopList, JikanEndPointCategories.Anime, "1", extension.GetDescription() };
 			return await ExecuteGetRequest<AnimeTop>(endpointParts);
 		}
@@ -865,6 +872,7 @@ namespace JikanDotNet
 		public async Task<AnimeTop> GetAnimeTop(int page, TopAnimeExtension extension = TopAnimeExtension.None)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
+			Guard.IsValidEnum(extension, nameof(extension));
 			string[] endpointParts = new string[] { JikanEndPointCategories.TopList, JikanEndPointCategories.Anime, page.ToString(), extension.GetDescription() };
 			return await ExecuteGetRequest<AnimeTop>(endpointParts);
 		}
@@ -902,6 +910,7 @@ namespace JikanDotNet
 		/// <returns>List of top manga.</returns>
 		public async Task<MangaTop> GetMangaTop(TopMangaExtension extension)
 		{
+			Guard.IsValidEnum(extension, nameof(extension));
 			string[] endpointParts = new string[] { JikanEndPointCategories.TopList, JikanEndPointCategories.Manga, "1", extension.GetDescription() };
 			return await ExecuteGetRequest<MangaTop>(endpointParts);
 		}
@@ -915,6 +924,7 @@ namespace JikanDotNet
 		public async Task<MangaTop> GetMangaTop(int page, TopMangaExtension extension = TopMangaExtension.None)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
+			Guard.IsValidEnum(extension, nameof(extension));
 			string[] endpointParts = new string[] { JikanEndPointCategories.TopList, JikanEndPointCategories.Manga, page.ToString(), extension.GetDescription() };
 			return await ExecuteGetRequest<MangaTop>(endpointParts);
 		}
@@ -1084,6 +1094,7 @@ namespace JikanDotNet
 		public async Task<UserHistory> GetUserHistory(string username, UserHistoryExtension historyExtension)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
+			Guard.IsValidEnum(historyExtension, nameof(historyExtension));
 			string[] endpointParts = new string[] { JikanEndPointCategories.User, username, UserExtension.History.GetDescription(), historyExtension.GetDescription() };
 			return await ExecuteGetRequest<UserHistory>(endpointParts);
 		}
@@ -1127,6 +1138,7 @@ namespace JikanDotNet
 		public async Task<UserAnimeList> GetUserAnimeList(string username, UserAnimeListExtension filter)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
+			Guard.IsValidEnum(filter, nameof(filter));
 			string[] endpointParts = new string[] { JikanEndPointCategories.User, username, UserExtension.AnimeList.GetDescription(), filter.GetDescription() };
 			return await ExecuteGetRequest<UserAnimeList>(endpointParts);
 		}
@@ -1142,6 +1154,7 @@ namespace JikanDotNet
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
+			Guard.IsValidEnum(filter, nameof(filter));
 			string[] endpointParts = new string[] { JikanEndPointCategories.User, username, UserExtension.AnimeList.GetDescription(), filter.GetDescription(), page.ToString() };
 			return await ExecuteGetRequest<UserAnimeList>(endpointParts);
 		}
@@ -1200,6 +1213,7 @@ namespace JikanDotNet
 		public async Task<UserMangaList> GetUserMangaList(string username, UserMangaListExtension filter)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
+			Guard.IsValidEnum(filter, nameof(filter));
 			string[] endpointParts = new string[] { JikanEndPointCategories.User, username, UserExtension.MangaList.GetDescription(), filter.GetDescription() };
 			return await ExecuteGetRequest<UserMangaList>(endpointParts);
 		}
@@ -1215,6 +1229,7 @@ namespace JikanDotNet
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
+			Guard.IsValidEnum(filter, nameof(filter));
 			string[] endpointParts = new string[] { JikanEndPointCategories.User, username, UserExtension.MangaList.GetDescription(), filter.GetDescription(), page.ToString() };
 			return await ExecuteGetRequest<UserMangaList>(endpointParts);
 		}

--- a/JikanDotNet/Model/Search/AnimeSearchConfig.cs
+++ b/JikanDotNet/Model/Search/AnimeSearchConfig.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using JikanDotNet.Helpers;
 
 namespace JikanDotNet
 {
@@ -78,6 +79,7 @@ namespace JikanDotNet
 
 			if (Type != AnimeType.EveryType)
 			{
+				Guard.IsValidEnum(Type, nameof(Type));
 				builder.Append($"&type={Type.GetDescription()}");
 			}
 
@@ -88,11 +90,13 @@ namespace JikanDotNet
 
 			if (Rating != AgeRating.EveryRating)
 			{
+				Guard.IsValidEnum(Rating, nameof(Rating));
 				builder.Append($"&rated={Rating.GetDescription()}");
 			}
 
 			if (Status != AiringStatus.EveryStatus)
 			{
+				Guard.IsValidEnum(Status, nameof(Status));
 				builder.Append($"&status={Status.GetDescription()}");
 			}
 
@@ -108,7 +112,11 @@ namespace JikanDotNet
 
 			if (Genres.Count > 0 )
 			{
-				var genresId = Genres.Select(x => x.GetDescription()).ToArray();
+				var genresId = Genres.Select(genreSearch =>
+				{
+					Guard.IsValidEnum(genreSearch, nameof(genreSearch));
+					return genreSearch.GetDescription();
+				}).ToArray();
 
 				builder.Append($"&genre={string.Join(",", genresId)}");
 			}
@@ -120,6 +128,8 @@ namespace JikanDotNet
 
 			if (OrderBy != AnimeSearchSortable.NoSorting)
 			{
+				Guard.IsValidEnum(OrderBy, nameof(OrderBy));
+				Guard.IsValidEnum(SortDirection, nameof(SortDirection));
 				builder.Append($"&order_by={OrderBy.GetDescription()}");
 				builder.Append($"&sort={SortDirection.GetDescription()}");
 			}

--- a/JikanDotNet/Model/Search/MangaSearchConfig.cs
+++ b/JikanDotNet/Model/Search/MangaSearchConfig.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using JikanDotNet.Helpers;
 
 namespace JikanDotNet
 {
@@ -77,6 +78,7 @@ namespace JikanDotNet
 			
 			if (Type != MangaType.EveryType)
 			{
+				Guard.IsValidEnum(Type, nameof(Type));
 				builder.Append($"&type={Type.GetDescription()}");
 			}
 
@@ -87,11 +89,13 @@ namespace JikanDotNet
 
 			if (Rating != AgeRating.EveryRating)
 			{
+				Guard.IsValidEnum(Rating, nameof(Rating));
 				builder.Append($"&rated={Rating.GetDescription()}");
 			}
 
 			if (Status != AiringStatus.EveryStatus)
 			{
+				Guard.IsValidEnum(Status, nameof(Status));
 				builder.Append($"&status={Status.GetDescription()}");
 			}
 
@@ -107,7 +111,11 @@ namespace JikanDotNet
 
 			if (Genres.Count > 0)
 			{
-				var genresId = Genres.Select(x => x.GetDescription()).ToArray();
+				var genresId = Genres.Select(genreSearch =>
+				{
+					Guard.IsValidEnum(genreSearch, nameof(genreSearch));
+					return genreSearch.GetDescription();
+				}).ToArray();
 
 				builder.Append($"&genre={string.Join(",", genresId)}");
 			}
@@ -119,6 +127,8 @@ namespace JikanDotNet
 
 			if (OrderBy != MangaSearchSortable.NoSorting)
 			{
+				Guard.IsValidEnum(OrderBy, nameof(OrderBy));
+				Guard.IsValidEnum(SortDirection, nameof(SortDirection));
 				builder.Append($"&order_by={OrderBy.GetDescription()}");
 				builder.Append($"&sort={SortDirection.GetDescription()}");
 			}

--- a/JikanDotNet/Model/Search/UserListAnimeSearchConfig.cs
+++ b/JikanDotNet/Model/Search/UserListAnimeSearchConfig.cs
@@ -1,6 +1,7 @@
 ﻿using JikanDotNet.Extensions;
 using JikanDotNet.Interfaces;
 using System.Text;
+using JikanDotNet.Helpers;
 
 namespace JikanDotNet
 {
@@ -74,11 +75,14 @@ namespace JikanDotNet
 
 			if (OrderBy != UserListAnimeSearchSortable.NoSorting)
 			{
+				Guard.IsValidEnum(OrderBy, nameof(OrderBy));
+				Guard.IsValidEnum(SortDirection, nameof(SortDirection));
 				builder.Append($"&order_by={OrderBy.GetDescription()}");
 				builder.Append($"&sort={SortDirection.GetDescription()}");
 
 				if (OrderBy2 != UserListAnimeSearchSortable.NoSorting)
 				{
+					Guard.IsValidEnum(OrderBy2, nameof(OrderBy2));
 					builder.Append($"&order_by2={OrderBy2.GetDescription()}");
 				}
 			}
@@ -90,12 +94,14 @@ namespace JikanDotNet
 
 			if (Year > 0)
 			{
+				Guard.IsValidEnum(Season, nameof(Season));
 				builder.Append($"&year={Year}");
 				builder.Append($"&season={Season.GetDescription()}");
 			}
 
 			if (AiringStatus != UserListAnimeAiringStatus.NoFilter)
 			{
+				Guard.IsValidEnum(AiringStatus, nameof(AiringStatus));
 				builder.Append($"&airing_status={AiringStatus.GetDescription()}");
 			}
 

--- a/JikanDotNet/Model/Search/UserListMangaSearchConfig.cs
+++ b/JikanDotNet/Model/Search/UserListMangaSearchConfig.cs
@@ -1,6 +1,7 @@
 ﻿using JikanDotNet.Extensions;
 using JikanDotNet.Interfaces;
 using System.Text;
+using JikanDotNet.Helpers;
 
 namespace JikanDotNet
 {
@@ -64,11 +65,14 @@ namespace JikanDotNet
 
 			if (OrderBy != UserListMangaSearchSortable.NoSorting)
 			{
+				Guard.IsValidEnum(OrderBy, nameof(OrderBy));
+				Guard.IsValidEnum(SortDirection, nameof(SortDirection));
 				builder.Append($"&order_by={OrderBy.GetDescription()}");
 				builder.Append($"&sort={SortDirection.GetDescription()}");
 
 				if (OrderBy2 != UserListMangaSearchSortable.NoSorting)
 				{
+					Guard.IsValidEnum(OrderBy2, nameof(OrderBy2));
 					builder.Append($"&order_by2={OrderBy2.GetDescription()}");
 				}
 			}
@@ -80,6 +84,7 @@ namespace JikanDotNet
 
 			if (PublishingStatus != UserListMangaPublishingStatus.NoFilter)
 			{
+				Guard.IsValidEnum(PublishingStatus, nameof(PublishingStatus));
 				builder.Append($"&publishing_status={PublishingStatus.GetDescription()}");
 			}
 


### PR DESCRIPTION
Resolves #28 
Add validation for enums passed as parameters to methods of `Jikan` class, add validation for enums inside `*SearchConfig` classes, when transforming config to string. If validating configs isn't needed - leave a comment about this and I'll revert commits. Cover all validations with tests.