### PR TITLE
EnumExtensions.GetDescription Micro-Optimization

### DIFF
--- a/JikanDotNet/Extensions/EnumExtensions.cs
+++ b/JikanDotNet/Extensions/EnumExtensions.cs
@@ -1,16 +1,13 @@
 using System;
 using System.ComponentModel;
-using System.Linq;
 using System.Reflection;
 
 namespace JikanDotNet.Extensions
 {
 	internal static class EnumExtensions
 	{
-		public static string GetDescription(this Enum source) => source
-					.GetType()
-					.GetMember(source.ToString())
-					.FirstOrDefault()
+		public static string GetDescription<T>(this T source) where T : Enum => typeof(T)
+					.GetField(source.ToString())
 					?.GetCustomAttribute<DescriptionAttribute>()
 					?.Description;
 	}


### PR DESCRIPTION
From my benchmarks, this appears to be ~25% faster and allocate a bit less memory per call

|                Method |        Mean |     Error |    StdDev | Allocated |
|---------------------- |------------:|----------:|----------:|----------:|
|   GetDescriptionJikan | 1,701.56 ns | 32.576 ns | 54.427 ns |     288 B |
| GetDescriptionGeneric | 1,283.37 ns | 25.371 ns | 24.918 ns |     256 B |