### PR TITLE
Implemented the CancellationToken pattern

### DIFF
--- a/JikanDotNet/Interfaces/IJikan.cs
+++ b/JikanDotNet/Interfaces/IJikan.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace JikanDotNet
@@ -8,1037 +9,1174 @@ namespace JikanDotNet
 	/// </summary>
 	public interface IJikan
 	{
-		#region Anime requests
-		
-		/// <summary>
-		/// Returns anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Anime with given MAL id.</returns>
-		Task<BaseJikanResponse<Anime>> GetAnimeAsync(long id);
-		
-		/// <summary>
-		/// Returns collections of characters of anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collection of characters of anime with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<AnimeCharacter>>> GetAnimeCharactersAsync(long id);
-		
-		/// <summary>
-		/// Returns collections of staff of anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collection of staff of anime with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<AnimeStaffPosition>>> GetAnimeStaffAsync(long id);
-		
-		/// <summary>
-		/// Returns list of episodes for anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>List of episodes with details.</returns>
-		Task<PaginatedJikanResponse<ICollection<AnimeEpisode>>> GetAnimeEpisodesAsync(long id);
+        #region Anime requests
 
-		/// <summary>
-		/// Returns list of episodes for anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
-		/// <returns>List of episodes with details.</returns>
-		Task<PaginatedJikanResponse<ICollection<AnimeEpisode>>> GetAnimeEpisodesAsync(long id, int page);
-		
-		/// <summary>
-		/// Returns details about specific episode.
-		/// </summary>
-		/// <param name="animeId">MAL id of anime.</param>
-		/// <param name="episodeId">Id of episode.</param>
-		/// <returns>Details about specific episode.</returns>
-		Task<BaseJikanResponse<AnimeEpisode>> GetAnimeEpisodeAsync(long animeId, int episodeId);
-		
-		/// <summary>
-		/// Returns collections of news related to anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collections of news related to anime with given MAL id.</returns>
-		Task<PaginatedJikanResponse<ICollection<News>>> GetAnimeNewsAsync(long id);
+        /// <summary>
+        /// Returns anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Anime with given MAL id.</returns>
+        Task<BaseJikanResponse<Anime>> GetAnimeAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collections of news related to anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
-		/// <returns>Collections of news related to anime with given MAL id.</returns>
-		Task<PaginatedJikanResponse<ICollection<News>>> GetAnimeNewsAsync(long id, int page);
-		
-		/// <summary>
-		/// Returns collections of forum topics related to anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collections of forum topics related to anime with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<ForumTopic>>> GetAnimeForumTopicsAsync(long id);
+        /// <summary>
+        /// Returns collections of characters of anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of characters of anime with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<AnimeCharacter>>> GetAnimeCharactersAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collections of forum topics related to anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <param name="type">ForumTopicType filter</param>
-		/// <returns>Collections of forum topics related to anime with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<ForumTopic>>> GetAnimeForumTopicsAsync(long id, ForumTopicType type);
-		
-		/// <summary>
-		/// Returns collections of videos related to anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collections of videos related to anime with given MAL id.</returns>
-		Task<BaseJikanResponse<AnimeVideos>> GetAnimeVideosAsync(long id);
-		
-		/// <summary>
-		/// Returns collections of links to pictures related to anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collections of links to pictures related to anime with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<ImagesSet>>> GetAnimePicturesAsync(long id);
+        /// <summary>
+        /// Returns collections of staff of anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of staff of anime with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<AnimeStaffPosition>>> GetAnimeStaffAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns statistics related to anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Statistics related to anime with given MAL id.</returns>
-		Task<BaseJikanResponse<AnimeStatistics>> GetAnimeStatisticsAsync(long id);
+        /// <summary>
+        /// Returns list of episodes for anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of episodes with details.</returns>
+        Task<PaginatedJikanResponse<ICollection<AnimeEpisode>>> GetAnimeEpisodesAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns additional information related to anime with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Additional information related to anime with given MAL id.</returns>
-		Task<BaseJikanResponse<MoreInfo>> GetAnimeMoreInfoAsync(long id);
+        /// <summary>
+        /// Returns list of episodes for anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of episodes with details.</returns>
+        Task<PaginatedJikanResponse<ICollection<AnimeEpisode>>> GetAnimeEpisodesAsync(long id, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of anime recommendation.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collection of anime recommendation.</returns>
-		Task<BaseJikanResponse<ICollection<Recommendation>>> GetAnimeRecommendationsAsync(long id);
+        /// <summary>
+        /// Returns details about specific episode.
+        /// </summary>
+        /// <param name="animeId">MAL id of anime.</param>
+        /// <param name="episodeId">Id of episode.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Details about specific episode.</returns>
+        Task<BaseJikanResponse<AnimeEpisode>> GetAnimeEpisodeAsync(long animeId, int episodeId, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of anime user updates.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collection of anime user updates.</returns>
-		Task<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>> GetAnimeUserUpdatesAsync(long id);
+        /// <summary>
+        /// Returns collections of news related to anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of news related to anime with given MAL id.</returns>
+        Task<PaginatedJikanResponse<ICollection<News>>> GetAnimeNewsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of anime user updates.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <param name="page">Index of page folding 75 records of top ranging (e.g. 1 will return first 75 records, 2 will return record from 76 to 150 etc.)</param>
-		/// <returns>Collection of anime user updates.</returns>
-		Task<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>> GetAnimeUserUpdatesAsync(long id, int page);
-		/// <summary>
-		/// Returns collection of anime reviews.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collection of anime reviews.</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetAnimeReviewsAsync(long id);
+        /// <summary>
+        /// Returns collections of news related to anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of news related to anime with given MAL id.</returns>
+        Task<PaginatedJikanResponse<ICollection<News>>> GetAnimeNewsAsync(long id, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of anime reviews.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <param name="page">Index of page folding 20 records of top ranging (e.g. 1 will return first 20 records, 2 will return record from 21 to 40 etc.)</param>
-		/// <returns>Collection of anime reviews.</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetAnimeReviewsAsync(long id, int page);
+        /// <summary>
+        /// Returns collections of forum topics related to anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of forum topics related to anime with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<ForumTopic>>> GetAnimeForumTopicsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of anime related entries.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collection of anime related entries.</returns>
-		Task<PaginatedJikanResponse<ICollection<RelatedEntry>>> GetAnimeRelationsAsync(long id);
+        /// <summary>
+        /// Returns collections of forum topics related to anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="type">ForumTopicType filter</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of forum topics related to anime with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<ForumTopic>>> GetAnimeForumTopicsAsync(long id, ForumTopicType type, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of anime openings and endings.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collection of anime openings and endings.</returns>
-		Task<BaseJikanResponse<AnimeThemes>> GetAnimeThemesAsync(long id);
-		
-		/// <summary>
-		/// Returns collection of external services links related to anime.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collection of external services links related to anime.</returns>
-		Task<BaseJikanResponse<ICollection<ExternalLink>>> GetAnimeExternalLinksAsync(long id);
-		
-		/// <summary>
-		/// Returns collection of external streaming services links related to anime.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Collection of external services links related to anime.</returns>
-		Task<BaseJikanResponse<ICollection<ExternalLink>>> GetAnimeStreamingLinksAsync(long id);
-		
-		/// <summary>
-		/// Returns anime with additional data.
-		/// </summary>
-		/// <param name="id">MAL id of anime.</param>
-		/// <returns>Anime with additional data.</returns>
-		Task<BaseJikanResponse<AnimeFull>> GetAnimeFullDataAsync(long id);
-		
-		#endregion Anime requests
+        /// <summary>
+        /// Returns collections of videos related to anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of videos related to anime with given MAL id.</returns>
+        Task<BaseJikanResponse<AnimeVideos>> GetAnimeVideosAsync(long id, CancellationToken cancellationToken = default);
 
-		#region Manga requests
+        /// <summary>
+        /// Returns collections of links to pictures related to anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of links to pictures related to anime with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<ImagesSet>>> GetAnimePicturesAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns manga with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Manga with given MAL id.</returns>
-		Task<BaseJikanResponse<Manga>> GetMangaAsync(long id);
+        /// <summary>
+        /// Returns statistics related to anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Statistics related to anime with given MAL id.</returns>
+        Task<BaseJikanResponse<AnimeStatistics>> GetAnimeStatisticsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collections of characters appearing in manga with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collections of characters appearing in manga with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<MangaCharacter>>> GetMangaCharactersAsync(long id);
+        /// <summary>
+        /// Returns additional information related to anime with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Additional information related to anime with given MAL id.</returns>
+        Task<BaseJikanResponse<MoreInfo>> GetAnimeMoreInfoAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collections of news related to manga with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collections of news related to manga with given MAL id.</returns>
-		Task<PaginatedJikanResponse<ICollection<News>>> GetMangaNewsAsync(long id);
+        /// <summary>
+        /// Returns collection of anime recommendation.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of anime recommendation.</returns>
+        Task<BaseJikanResponse<ICollection<Recommendation>>> GetAnimeRecommendationsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collections of news related to manga with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
-		/// <returns>Collections of news related to manga with given MAL id.</returns>
-		Task<PaginatedJikanResponse<ICollection<News>>> GetMangaNewsAsync(long id, int page);
+        /// <summary>
+        /// Returns collection of anime user updates.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of anime user updates.</returns>
+        Task<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>> GetAnimeUserUpdatesAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collections of forum topics related to manga with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collections of forum topics related to manga with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<ForumTopic>>> GetMangaForumTopicsAsync(long id);
+        /// <summary>
+        /// Returns collection of anime user updates.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="page">Index of page folding 75 records of top ranging (e.g. 1 will return first 75 records, 2 will return record from 76 to 150 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of anime user updates.</returns>
+        Task<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>> GetAnimeUserUpdatesAsync(long id, int page, CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Returns collection of anime reviews.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of anime reviews.</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetAnimeReviewsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collections of links to pictures related to manga with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collections of links to pictures related to manga with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<ImagesSet>>> GetMangaPicturesAsync(long id);
+        /// <summary>
+        /// Returns collection of anime reviews.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <param name="page">Index of page folding 20 records of top ranging (e.g. 1 will return first 20 records, 2 will return record from 21 to 40 etc.)</param>
+        /// <returns>Collection of anime reviews.</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetAnimeReviewsAsync(long id, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns statistics related to manga with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Statistics related to manga with given MAL id.</returns>
-		Task<BaseJikanResponse<MangaStatistics>> GetMangaStatisticsAsync(long id);
+        /// <summary>
+        /// Returns collection of anime related entries.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of anime related entries.</returns>
+        Task<PaginatedJikanResponse<ICollection<RelatedEntry>>> GetAnimeRelationsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns additional information related to manga with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collections of forum topics related to manga with given MAL id.</returns>
-		Task<BaseJikanResponse<MoreInfo>> GetMangaMoreInfoAsync(long id);
+        /// <summary>
+        /// Returns collection of anime openings and endings.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of anime openings and endings.</returns>
+        Task<BaseJikanResponse<AnimeThemes>> GetAnimeThemesAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of manga user updates.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collection of manga user updates.</returns>
-		Task<PaginatedJikanResponse<ICollection<MangaUserUpdate>>> GetMangaUserUpdatesAsync(long id);
+        /// <summary>
+        /// Returns collection of external services links related to anime.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of external services links related to anime.</returns>
+        Task<BaseJikanResponse<ICollection<ExternalLink>>> GetAnimeExternalLinksAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of manga user updates.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <param name="page">Index of page folding 75 records of top ranging (e.g. 1 will return first 75 records, 2 will return record from 76 to 150 etc.)</param>
-		/// <returns>Collection of manga user updates.</returns>
-		Task<PaginatedJikanResponse<ICollection<MangaUserUpdate>>> GetMangaUserUpdatesAsync(long id, int page);
+        /// <summary>
+        /// Returns collection of external streaming services links related to anime.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of external services links related to anime.</returns>
+        Task<BaseJikanResponse<ICollection<ExternalLink>>> GetAnimeStreamingLinksAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of manga recommendation.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collection of manga recomendation.</returns>
-		Task<BaseJikanResponse<ICollection<Recommendation>>> GetMangaRecommendationsAsync(long id);
+        /// <summary>
+        /// Returns anime with additional data.
+        /// </summary>
+        /// <param name="id">MAL id of anime.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Anime with additional data.</returns>
+        Task<BaseJikanResponse<AnimeFull>> GetAnimeFullDataAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collection of manga reviews.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collection of manga reviews.</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id);
+        #endregion Anime requests
 
-		/// <summary>
-		/// Returns collection of manga related entries.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collection of manga related entries.</returns>
-		Task<PaginatedJikanResponse<ICollection<RelatedEntry>>> GetMangaRelationsAsync(long id);
-		
-		/// <summary>
-		/// Returns collection of external services links related to manga.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Collection of external services links related to anime.</returns>
-		Task<BaseJikanResponse<ICollection<ExternalLink>>> GetMangaExternalLinksAsync(long id);
-		
-		/// <summary>
-		/// Returns manga with additional data.
-		/// </summary>
-		/// <param name="id">MAL id of manga.</param>
-		/// <returns>Manga with additional data.</returns>
-		Task<BaseJikanResponse<MangaFull>> GetMangaFullDataAsync(long id);
+        #region Manga requests
 
-		#endregion Manga requests
+        /// <summary>
+        /// Returns manga with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Manga with given MAL id.</returns>
+        Task<BaseJikanResponse<Manga>> GetMangaAsync(long id, CancellationToken cancellationToken = default);
 
-		#region Character requests
+        /// <summary>
+        /// Returns collections of characters appearing in manga with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of characters appearing in manga with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<MangaCharacter>>> GetMangaCharactersAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns character with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of character.</param>
-		/// <returns>Character with given MAL id.</returns>
-		Task<BaseJikanResponse<Character>> GetCharacterAsync(long id);
+        /// <summary>
+        /// Returns collections of news related to manga with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of news related to manga with given MAL id.</returns>
+        Task<PaginatedJikanResponse<ICollection<News>>> GetMangaNewsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns animeography of character with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of character.</param>
-		/// <returns>Collection of anime where character has appeared.</returns>
-		Task<BaseJikanResponse<ICollection<CharacterAnimeographyEntry>>> GetCharacterAnimeAsync(long id);
+        /// <summary>
+        /// Returns collections of news related to manga with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of news related to manga with given MAL id.</returns>
+        Task<PaginatedJikanResponse<ICollection<News>>> GetMangaNewsAsync(long id, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns mangaography of character with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of character.</param>
-		/// <returns>Collection of manga where character has appeared.</returns>
-		Task<BaseJikanResponse<ICollection<CharacterMangaographyEntry>>> GetCharacterMangaAsync(long id);
+        /// <summary>
+        /// Returns collections of forum topics related to manga with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of forum topics related to manga with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<ForumTopic>>> GetMangaForumTopicsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns voice actors of character with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of character.</param>
-		/// <returns>Collection of voice actors voicing character.</returns>
-		Task<BaseJikanResponse<ICollection<VoiceActorEntry>>> GetCharacterVoiceActorsAsync(long id);
+        /// <summary>
+        /// Returns collections of links to pictures related to manga with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of links to pictures related to manga with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<ImagesSet>>> GetMangaPicturesAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collections of links to pictures related to character with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of character.</param>
-		/// <returns>Collections of links to pictures related to character with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<ImagesSet>>> GetCharacterPicturesAsync(long id);
-		
-		/// <summary>
-		/// Returns character with additional data.
-		/// </summary>
-		/// <param name="id">MAL id of character.</param>
-		/// <returns>Character with additional data.</returns>
-		Task<BaseJikanResponse<CharacterFull>> GetCharacterFullDataAsync(long id);
+        /// <summary>
+        /// Returns statistics related to manga with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Statistics related to manga with given MAL id.</returns>
+        Task<BaseJikanResponse<MangaStatistics>> GetMangaStatisticsAsync(long id, CancellationToken cancellationToken = default);
 
-		#endregion Character requests
+        /// <summary>
+        /// Returns additional information related to manga with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of forum topics related to manga with given MAL id.</returns>
+        Task<BaseJikanResponse<MoreInfo>> GetMangaMoreInfoAsync(long id, CancellationToken cancellationToken = default);
 
-		#region Person requests
+        /// <summary>
+        /// Returns collection of manga user updates.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of manga user updates.</returns>
+        Task<PaginatedJikanResponse<ICollection<MangaUserUpdate>>> GetMangaUserUpdatesAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns person with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of person.</param>
-		/// <returns>Person with given MAL id.</returns>
-		Task<BaseJikanResponse<Person>> GetPersonAsync(long id);
-		
-		/// <summary>
-		/// Returns animeography of person with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of person.</param>
-		/// <returns>Collection of anime the person collaborated on.</returns>
-		Task<BaseJikanResponse<ICollection<PersonAnimeographyEntry>>> GetPersonAnimeAsync(long id);
+        /// <summary>
+        /// Returns collection of manga user updates.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="page">Index of page folding 75 records of top ranging (e.g. 1 will return first 75 records, 2 will return record from 76 to 150 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of manga user updates.</returns>
+        Task<PaginatedJikanResponse<ICollection<MangaUserUpdate>>> GetMangaUserUpdatesAsync(long id, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns mangaography of person with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of person.</param>
-		/// <returns>Collection of manga the person worked on.</returns>
-		Task<BaseJikanResponse<ICollection<PersonMangaographyEntry>>> GetPersonMangaAsync(long id);
+        /// <summary>
+        /// Returns collection of manga recommendation.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of manga recomendation.</returns>
+        Task<BaseJikanResponse<ICollection<Recommendation>>> GetMangaRecommendationsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns voice acting roles of person with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of person.</param>
-		/// <returns>Collection of voice acting roles of the person.</returns>
-		Task<BaseJikanResponse<ICollection<VoiceActingRole>>> GetPersonVoiceActingRolesAsync(long id);
+        /// <summary>
+        /// Returns collection of manga reviews.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of manga reviews.</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns collections of links to pictures related to person with given MAL id.
-		/// </summary>
-		/// <param name="id">MAL id of person.</param>
-		/// <returns>Collections of links to pictures related to person with given MAL id.</returns>
-		Task<BaseJikanResponse<ICollection<ImagesSet>>> GetPersonPicturesAsync(long id);
-		
-		/// <summary>
-		/// Returns person with additional data.
-		/// </summary>
-		/// <param name="id">MAL id of person.</param>
-		/// <returns>Person with additional data.</returns>
-		Task<BaseJikanResponse<PersonFull>> GetPersonFullDataAsync(long id);
+        /// <summary>
+        /// Returns collection of manga related entries.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of manga related entries.</returns>
+        Task<PaginatedJikanResponse<ICollection<RelatedEntry>>> GetMangaRelationsAsync(long id, CancellationToken cancellationToken = default);
 
-		#endregion Person requests
+        /// <summary>
+        /// Returns collection of external services links related to manga.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of external services links related to anime.</returns>
+        Task<BaseJikanResponse<ICollection<ExternalLink>>> GetMangaExternalLinksAsync(long id, CancellationToken cancellationToken = default);
 
-		#region Season requests
+        /// <summary>
+        /// Returns manga with additional data.
+        /// </summary>
+        /// <param name="id">MAL id of manga.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Manga with additional data.</returns>
+        Task<BaseJikanResponse<MangaFull>> GetMangaFullDataAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns season preview.
-		/// </summary>
-		/// <param name="year">Year of selected season.</param>
-		/// <param name="season">Selected season.</param>
-		/// <returns>Season preview.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetSeasonAsync(int year, Season season);
+        #endregion Manga requests
 
-		/// <summary>
-		/// Returns season preview.
-		/// </summary>
-		/// <param name="year">Year of selected season.</param>
-		/// <param name="season">Selected season.</param>
-		/// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
-		/// <returns>Season preview.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetSeasonAsync(int year, Season season, int page);
+        #region Character requests
 
-		/// <summary>
-		/// Returns list of available season to query with <see cref="GetSeasonAsync(int, Season)"/>
-		/// </summary>
-		/// <returns></returns>
-		Task<PaginatedJikanResponse<ICollection<SeasonArchive>>> GetSeasonArchiveAsync();
+        /// <summary>
+        /// Returns character with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of character.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Character with given MAL id.</returns>
+        Task<BaseJikanResponse<Character>> GetCharacterAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Return season preview for anime in current airing season.
-		/// </summary>
-		/// <returns>Season preview for anime in current airing season.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetCurrentSeasonAsync();
+        /// <summary>
+        /// Returns animeography of character with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of character.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of anime where character has appeared.</returns>
+        Task<BaseJikanResponse<ICollection<CharacterAnimeographyEntry>>> GetCharacterAnimeAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Return season preview for anime in current airing season.
-		/// </summary>
-		/// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
-		/// <returns>Season preview for anime in current airing season.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetCurrentSeasonAsync(int page);
+        /// <summary>
+        /// Returns mangaography of character with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of character.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of manga where character has appeared.</returns>
+        Task<BaseJikanResponse<ICollection<CharacterMangaographyEntry>>> GetCharacterMangaAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Return season preview for anime with undefined airing season (marked as "Later" on MAL).
-		/// </summary>
-		/// <returns>Season preview for anime with undefined airing date.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetUpcomingSeasonAsync();
-		
-		/// <summary>
-		/// Return season preview for anime with undefined airing season (marked as "Later" on MAL).
-		/// </summary>
-		/// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
-		/// <returns>Season preview for anime with undefined airing date.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetUpcomingSeasonAsync(int page);
+        /// <summary>
+        /// Returns voice actors of character with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of character.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of voice actors voicing character.</returns>
+        Task<BaseJikanResponse<ICollection<VoiceActorEntry>>> GetCharacterVoiceActorsAsync(long id, CancellationToken cancellationToken = default);
 
-		#endregion Season requests
+        /// <summary>
+        /// Returns collections of links to pictures related to character with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of character.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of links to pictures related to character with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<ImagesSet>>> GetCharacterPicturesAsync(long id, CancellationToken cancellationToken = default);
 
-		#region Schedule requests
+        /// <summary>
+        /// Returns character with additional data.
+        /// </summary>
+        /// <param name="id">MAL id of character.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Character with additional data.</returns>
+        Task<BaseJikanResponse<CharacterFull>> GetCharacterFullDataAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns current season schedule.
-		/// </summary>
-		/// <returns>Current season schedule.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync();
+        #endregion Character requests
 
-		/// <summary>
-		/// Returns current season schedule.
-		/// </summary>
-		/// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
-		/// <returns>Current season schedule.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(int page);
+        #region Person requests
 
-		/// <summary>
-		/// Returns current season schedule.
-		/// </summary>
-		/// <param name="scheduledDay">Scheduled day to filter by.</param>
-		/// <returns>Current season schedule.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(ScheduledDay scheduledDay);
+        /// <summary>
+        /// Returns person with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of person.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Person with given MAL id.</returns>
+        Task<BaseJikanResponse<Person>> GetPersonAsync(long id, CancellationToken cancellationToken = default);
 
-		#endregion Schedule requests
+        /// <summary>
+        /// Returns animeography of person with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of person.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of anime the person collaborated on.</returns>
+        Task<BaseJikanResponse<ICollection<PersonAnimeographyEntry>>> GetPersonAnimeAsync(long id, CancellationToken cancellationToken = default);
 
-		#region Top requests
+        /// <summary>
+        /// Returns mangaography of person with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of person.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of manga the person worked on.</returns>
+        Task<BaseJikanResponse<ICollection<PersonMangaographyEntry>>> GetPersonMangaAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of top anime.
-		/// </summary>
-		/// <returns>List of top anime.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync();
+        /// <summary>
+        /// Returns voice acting roles of person with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of person.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of voice acting roles of the person.</returns>
+        Task<BaseJikanResponse<ICollection<VoiceActingRole>>> GetPersonVoiceActingRolesAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of top anime.
-		/// </summary>
-		/// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
-		/// <returns>List of top anime.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(int page);
+        /// <summary>
+        /// Returns collections of links to pictures related to person with given MAL id.
+        /// </summary>
+        /// <param name="id">MAL id of person.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collections of links to pictures related to person with given MAL id.</returns>
+        Task<BaseJikanResponse<ICollection<ImagesSet>>> GetPersonPicturesAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of top anime.
-		/// </summary>
-		/// <param name="filter">Filter determining result of request (e.g. TopAnimeFilter.Airing will return top airing anime.)</param>
-		/// <returns>List of top anime.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(TopAnimeFilter filter);
+        /// <summary>
+        /// Returns person with additional data.
+        /// </summary>
+        /// <param name="id">MAL id of person.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Person with additional data.</returns>
+        Task<BaseJikanResponse<PersonFull>> GetPersonFullDataAsync(long id, CancellationToken cancellationToken = default);
+
+        #endregion Person requests
+
+        #region Season requests
+
+        /// <summary>
+        /// Returns season preview.
+        /// </summary>
+        /// <param name="year">Year of selected season.</param>
+        /// <param name="season">Selected season.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Season preview.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetSeasonAsync(int year, Season season, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns season preview.
+        /// </summary>
+        /// <param name="year">Year of selected season.</param>
+        /// <param name="season">Selected season.</param>
+        /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Season preview.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetSeasonAsync(int year, Season season, int page, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of available season to query with <see cref="GetSeasonAsync(int, Season, CancellationToken)"/>
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns></returns>
+        Task<PaginatedJikanResponse<ICollection<SeasonArchive>>> GetSeasonArchiveAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Return season preview for anime in current airing season.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Season preview for anime in current airing season.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetCurrentSeasonAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Return season preview for anime in current airing season.
+        /// </summary>
+        /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Season preview for anime in current airing season.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetCurrentSeasonAsync(int page, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Return season preview for anime with undefined airing season (marked as "Later" on MAL).
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Season preview for anime with undefined airing date.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetUpcomingSeasonAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Return season preview for anime with undefined airing season (marked as "Later" on MAL).
+        /// </summary>
+        /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Season preview for anime with undefined airing date.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetUpcomingSeasonAsync(int page, CancellationToken cancellationToken = default);
+
+        #endregion Season requests
+
+        #region Schedule requests
+
+        /// <summary>
+        /// Returns current season schedule.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Current season schedule.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns current season schedule.
+        /// </summary>
+        /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Current season schedule.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(int page, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns current season schedule.
+        /// </summary>
+        /// <param name="scheduledDay">Scheduled day to filter by.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Current season schedule.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(ScheduledDay scheduledDay, CancellationToken cancellationToken = default);
+
+        #endregion Schedule requests
+
+        #region Top requests
+
+        /// <summary>
+        /// Returns list of top anime.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of top anime.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of top anime.
+        /// </summary>
+        /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of top anime.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(int page, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of top anime.
+        /// </summary>
+        /// <param name="filter">Filter determining result of request (e.g. TopAnimeFilter.Airing will return top airing anime.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of top anime.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(TopAnimeFilter filter, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns list of top anime.
         /// </summary>
         /// <param name="filter">Filter determining result of request (e.g. TopAnimeFilter.Airing will return top airing anime.)</param>
         /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>List of top anime.</returns>
-        Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(TopAnimeFilter filter, int page);
+        Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(TopAnimeFilter filter, int page, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns list of top manga.
         /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>List of top manga.</returns>
-        Task<PaginatedJikanResponse<ICollection<Manga>>> GetTopMangaAsync();
+        Task<PaginatedJikanResponse<ICollection<Manga>>> GetTopMangaAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of top manga.
-		/// </summary>
-		/// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
-		/// <returns>List of top manga.</returns>
-		Task<PaginatedJikanResponse<ICollection<Manga>>> GetTopMangaAsync(int page);
+        /// <summary>
+        /// Returns list of top manga.
+        /// </summary>
+        /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of top manga.</returns>
+        Task<PaginatedJikanResponse<ICollection<Manga>>> GetTopMangaAsync(int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of most popular people.
-		/// </summary>
-		/// <returns>List of most popular people.</returns>
-		Task<PaginatedJikanResponse<ICollection<Person>>> GetTopPeopleAsync();
+        /// <summary>
+        /// Returns list of most popular people.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of most popular people.</returns>
+        Task<PaginatedJikanResponse<ICollection<Person>>> GetTopPeopleAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of most popular people.
-		/// </summary>
-		/// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
-		/// <returns>List of most popular people.</returns>
-		Task<PaginatedJikanResponse<ICollection<Person>>> GetTopPeopleAsync(int page);
+        /// <summary>
+        /// Returns list of most popular people.
+        /// </summary>
+        /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of most popular people.</returns>
+        Task<PaginatedJikanResponse<ICollection<Person>>> GetTopPeopleAsync(int page, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Returns list of most popular characters.
 		/// </summary>
 		/// <returns>List of most popular characters.</returns>
-		Task<PaginatedJikanResponse<ICollection<Character>>> GetTopCharactersAsync();
+		Task<PaginatedJikanResponse<ICollection<Character>>> GetTopCharactersAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of most popular characters.
-		/// </summary>
-		/// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
-		/// <returns>List of most popular characters.</returns>
-		Task<PaginatedJikanResponse<ICollection<Character>>> GetTopCharactersAsync(int page);
+        /// <summary>
+        /// Returns list of most popular characters.
+        /// </summary>
+        /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of most popular characters.</returns>
+        Task<PaginatedJikanResponse<ICollection<Character>>> GetTopCharactersAsync(int page, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Returns list of most popular reviews.
 		/// </summary>
 		/// <returns>List of most popular reviews.</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetTopReviewsAsync();
+		Task<PaginatedJikanResponse<ICollection<Review>>> GetTopReviewsAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of most popular reviews.
-		/// </summary>
-		/// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
-		/// <returns>List of most popular reviews.</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetTopReviewsAsync(int page);
+        /// <summary>
+        /// Returns list of most popular reviews.
+        /// </summary>
+        /// <param name="page">Index of page folding 25 records of top ranging (e.g. 1 will return first 25 records, 2 will return record from 26 to 50 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of most popular reviews.</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetTopReviewsAsync(int page, CancellationToken cancellationToken = default);
 
-		#endregion Top requests
+        #endregion Top requests
 
-		#region Genre requests
+        #region Genre requests
 
-		/// <summary>
-		/// Returns list of anime genres.
-		/// </summary>
-		/// <returns>List of anime genres</returns>
-		Task<BaseJikanResponse<ICollection<Genre>>> GetAnimeGenresAsync();
+        /// <summary>
+        /// Returns list of anime genres.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of anime genres</returns>
+        Task<BaseJikanResponse<ICollection<Genre>>> GetAnimeGenresAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of anime genres.
-		/// </summary>
-		/// <param name="filter">Filter for genre types.</param>
-		/// <returns>List of anime genres</returns>
-		Task<BaseJikanResponse<ICollection<Genre>>> GetAnimeGenresAsync(GenresFilter filter);
+        /// <summary>
+        /// Returns list of anime genres.
+        /// </summary>
+        /// <param name="filter">Filter for genre types.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of anime genres</returns>
+        Task<BaseJikanResponse<ICollection<Genre>>> GetAnimeGenresAsync(GenresFilter filter, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of manga genres.
-		/// </summary>
-		/// <returns>List of manga genres</returns>
-		Task<BaseJikanResponse<ICollection<Genre>>> GetMangaGenresAsync();
+        /// <summary>
+        /// Returns list of manga genres.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of manga genres</returns>
+        Task<BaseJikanResponse<ICollection<Genre>>> GetMangaGenresAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of manga genres.
-		/// </summary>
-		/// <param name="filter">Filter for genre types.</param>
-		/// <returns>List of manga genres</returns>
-		Task<BaseJikanResponse<ICollection<Genre>>> GetMangaGenresAsync(GenresFilter filter);
+        /// <summary>
+        /// Returns list of manga genres.
+        /// </summary>
+        /// <param name="filter">Filter for genre types.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of manga genres</returns>
+        Task<BaseJikanResponse<ICollection<Genre>>> GetMangaGenresAsync(GenresFilter filter, CancellationToken cancellationToken = default);
 
-		#endregion Genre requests
+        #endregion Genre requests
 
-		#region Producer requests
+        #region Producer requests
 
-		/// <summary>
-		/// Returns information about producers.
-		/// </summary>
-		/// <returns>Basic Information about producers.</returns>
-		Task<PaginatedJikanResponse<ICollection<Producer>>> GetProducersAsync();
+        /// <summary>
+        /// Returns information about producers.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Basic Information about producers.</returns>
+        Task<PaginatedJikanResponse<ICollection<Producer>>> GetProducersAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns information about producers.
-		/// </summary>
-		/// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
-		/// <returns>Basic Information about producers.</returns>
-		Task<PaginatedJikanResponse<ICollection<Producer>>> GetProducersAsync(int page);
-		
-		/// <summary>
-		/// Returns information about producer.
-		/// </summary>
-		/// <param name="id">MAL id of the producer.</param>
-		/// <returns>Basic Information about producer.</returns>
-		Task<BaseJikanResponse<Producer>> GetProducerAsync(long id);
-		
-		/// <summary>
-		/// Returns external links related to producer
-		/// </summary>
-		/// <param name="id">MAL id of the producer.</param>
-		/// <returns>External links related to producer</returns>
-		Task<BaseJikanResponse<ICollection<ExternalLink>>> GetProducerExternalLinksAsync(long id);
-		
-		/// <summary>
-		/// Returns full information about producer.
-		/// </summary>
-		/// <param name="id">MAL id of the producer.</param>
-		/// <returns>Full Information about producer.</returns>
-		Task<BaseJikanResponse<ProducerFull>> GetProducerFullDataAsync(long id);
+        /// <summary>
+        /// Returns information about producers.
+        /// </summary>
+        /// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Basic Information about producers.</returns>
+        Task<PaginatedJikanResponse<ICollection<Producer>>> GetProducersAsync(int page, CancellationToken cancellationToken = default);
 
-		#endregion Producer requests
+        /// <summary>
+        /// Returns information about producer.
+        /// </summary>
+        /// <param name="id">MAL id of the producer.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Basic Information about producer.</returns>
+        Task<BaseJikanResponse<Producer>> GetProducerAsync(long id, CancellationToken cancellationToken = default);
 
-		#region Magazine requests
+        /// <summary>
+        /// Returns external links related to producer
+        /// </summary>
+        /// <param name="id">MAL id of the producer.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>External links related to producer</returns>
+        Task<BaseJikanResponse<ICollection<ExternalLink>>> GetProducerExternalLinksAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns information about magazines.
-		/// </summary>
-		/// <returns>Basic Information about magazines.</returns>
-		Task<PaginatedJikanResponse<ICollection<Magazine>>> GetMagazinesAsync();
+        /// <summary>
+        /// Returns full information about producer.
+        /// </summary>
+        /// <param name="id">MAL id of the producer.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Full Information about producer.</returns>
+        Task<BaseJikanResponse<ProducerFull>> GetProducerFullDataAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns information about magazines.
-		/// </summary>
-		/// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
-		/// <returns>Basic Information about magazines.</returns>
-		Task<PaginatedJikanResponse<ICollection<Magazine>>> GetMagazinesAsync(int page);
+        #endregion Producer requests
 
-		#endregion Magazine requests
+        #region Magazine requests
 
-		#region Club requests
+        /// <summary>
+        /// Returns information about magazines.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Basic Information about magazines.</returns>
+        Task<PaginatedJikanResponse<ICollection<Magazine>>> GetMagazinesAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Return club's profile information.
-		/// </summary>
-		/// <param name="id">MAL id of the club.</param>
-		/// <returns>Club's profile information.</returns>
-		Task<BaseJikanResponse<Club>> GetClubAsync(long id);
+        /// <summary>
+        /// Returns information about magazines.
+        /// </summary>
+        /// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Basic Information about magazines.</returns>
+        Task<PaginatedJikanResponse<ICollection<Magazine>>> GetMagazinesAsync(int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Return club's member list.
-		/// </summary>
-		/// <param name="id">MAL id of the club.</param>
-		/// <returns>Club's member list.</returns>
-		Task<PaginatedJikanResponse<ICollection<ClubMember>>> GetClubMembersAsync(long id);
+        #endregion Magazine requests
 
-		/// <summary>
-		/// Return club's member list.
-		/// </summary>
-		/// <param name="id">MAL id of the club.</param>
-		/// <param name="page">Index of page folding 36 records of top ranging (e.g. 1 will return first 36 records, 2 will return record from 37 to 72 etc.)</param>
-		/// <returns>Club's member list.</returns>
-		Task<PaginatedJikanResponse<ICollection<ClubMember>>> GetClubMembersAsync(long id, int page);
+        #region Club requests
 
-		/// <summary>
-		/// Return club's staff list.
-		/// </summary>
-		/// <param name="id">MAL id of the club.</param>
-		/// <returns>Club's staff list.</returns>
-		Task<BaseJikanResponse<ICollection<ClubStaff>>> GetClubStaffAsync(long id);
+        /// <summary>
+        /// Return club's profile information.
+        /// </summary>
+        /// <param name="id">MAL id of the club.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Club's profile information.</returns>
+        Task<BaseJikanResponse<Club>> GetClubAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Return club's related entities.
-		/// </summary>
-		/// <param name="id">MAL id of the club.</param>
-		/// <returns>Club's related entities collections..</returns>
-		Task<BaseJikanResponse<ClubRelations>> GetClubRelationsAsync(long id);
+        /// <summary>
+        /// Return club's member list.
+        /// </summary>
+        /// <param name="id">MAL id of the club.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Club's member list.</returns>
+        Task<PaginatedJikanResponse<ICollection<ClubMember>>> GetClubMembersAsync(long id, CancellationToken cancellationToken = default);
 
-		#endregion Club requests
+        /// <summary>
+        /// Return club's member list.
+        /// </summary>
+        /// <param name="id">MAL id of the club.</param>
+        /// <param name="page">Index of page folding 36 records of top ranging (e.g. 1 will return first 36 records, 2 will return record from 37 to 72 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Club's member list.</returns>
+        Task<PaginatedJikanResponse<ICollection<ClubMember>>> GetClubMembersAsync(long id, int page, CancellationToken cancellationToken = default);
 
-		#region User requests
-		
-		/// <summary>
-		/// Returns information about user's profile with given username.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Information about user's profile with given username.</returns>
-		Task<BaseJikanResponse<UserProfile>> GetUserProfileAsync(string username);
+        /// <summary>
+        /// Return club's staff list.
+        /// </summary>
+        /// <param name="id">MAL id of the club.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Club's staff list.</returns>
+        Task<BaseJikanResponse<ICollection<ClubStaff>>> GetClubStaffAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns information about user's anime and manga statistics
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Information about user's anime and manga statistics.</returns>
-		Task<BaseJikanResponse<UserStatistics>> GetUserStatisticsAsync(string username);
+        /// <summary>
+        /// Return club's related entities.
+        /// </summary>
+        /// <param name="id">MAL id of the club.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Club's related entities collections..</returns>
+        Task<BaseJikanResponse<ClubRelations>> GetClubRelationsAsync(long id, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns information about user's favorite section.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Information about user's favorite section..</returns>
-		Task<BaseJikanResponse<UserFavorites>> GetUserFavoritesAsync(string username);
-		
-		/// <summary>
-		/// Returns information about user's updates on anime/manga progress.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Information about user's updates on anime/manga progress.</returns>
-		Task<BaseJikanResponse<UserUpdates>> GetUserUpdatesAsync(string username);
+        #endregion Club requests
 
-		/// <summary>
-		/// Returns information about user's description on the profile.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Information about user's description on the profile.</returns>
-		Task<BaseJikanResponse<UserAbout>> GetUserAboutAsync(string username);
+        #region User requests
 
-		/// <summary>
-		/// Returns information about user's history with given username.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Information about user's profile with given username.</returns>
-		Task<BaseJikanResponse<ICollection<HistoryEntry>>> GetUserHistoryAsync(string username);
+        /// <summary>
+        /// Returns information about user's profile with given username.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Information about user's profile with given username.</returns>
+        Task<BaseJikanResponse<UserProfile>> GetUserProfileAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns information about user's history with given username.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <param name="filter">Option to filter history.</param>
-		/// <returns>Information about user's profile with given username.</returns>
-		Task<BaseJikanResponse<ICollection<HistoryEntry>>> GetUserHistoryAsync(string username, UserHistoryExtension filter);
+        /// <summary>
+        /// Returns information about user's anime and manga statistics
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Information about user's anime and manga statistics.</returns>
+        Task<BaseJikanResponse<UserStatistics>> GetUserStatisticsAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns information about user's friends with given username.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Information about user's friends with given username.</returns>
-		Task<PaginatedJikanResponse<ICollection<Friend>>> GetUserFriendsAsync(string username);
+        /// <summary>
+        /// Returns information about user's favorite section.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Information about user's favorite section..</returns>
+        Task<BaseJikanResponse<UserFavorites>> GetUserFavoritesAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns information about user's friends with given username.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <param name="page">Index of the page.</param>
-		/// <returns>Information about user's friends with given username.</returns>
-		Task<PaginatedJikanResponse<ICollection<Friend>>> GetUserFriendsAsync(string username, int page);
+        /// <summary>
+        /// Returns information about user's updates on anime/manga progress.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Information about user's updates on anime/manga progress.</returns>
+        Task<BaseJikanResponse<UserUpdates>> GetUserUpdatesAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns entries on user's anime list.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Entries on user's anime list.</returns>
-		Task<BaseJikanResponse<ICollection<AnimeListEntry>>> GetUserAnimeListAsync(string username);
+        /// <summary>
+        /// Returns information about user's description on the profile.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Information about user's description on the profile.</returns>
+        Task<BaseJikanResponse<UserAbout>> GetUserAboutAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns entries on user's anime list.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <param name="page">Index of page folding 300 records of top ranging (e.g. 1 will return first 300 records, 2 will return record from 301 to 600 etc.)</param>
-		/// <returns>Entries on user's anime list.</returns>
-		Task<BaseJikanResponse<ICollection<AnimeListEntry>>> GetUserAnimeListAsync(string username, int page);
+        /// <summary>
+        /// Returns information about user's history with given username.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Information about user's profile with given username.</returns>
+        Task<BaseJikanResponse<ICollection<HistoryEntry>>> GetUserHistoryAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns entries on user's manga list.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Entries on user's manga list.</returns>
-		Task<BaseJikanResponse<ICollection<MangaListEntry>>> GetUserMangaListAsync(string username);
+        /// <summary>
+        /// Returns information about user's history with given username.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="filter">Option to filter history.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Information about user's profile with given username.</returns>
+        Task<BaseJikanResponse<ICollection<HistoryEntry>>> GetUserHistoryAsync(string username, UserHistoryExtension filter, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns entries on user's manga list.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <param name="page">Index of page folding 300 records of top ranging (e.g. 1 will return first 300 records, 2 will return record from 301 to 600 etc.)</param>
-		/// <returns>Entries on user's manga list.</returns>
-		Task<BaseJikanResponse<ICollection<MangaListEntry>>> GetUserMangaListAsync(string username, int page);
-		
-		/// <summary>
-		/// Returns user's reviews.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>User's reviews.</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetUserReviewsAsync(string username);
+        /// <summary>
+        /// Returns information about user's friends with given username.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Information about user's friends with given username.</returns>
+        Task<PaginatedJikanResponse<ICollection<Friend>>> GetUserFriendsAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns user's reviews.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <param name="page">Index of page folding 10 records of top ranging (e.g. 1 will return first 10 records, 2 will return record from 11 to 21 etc.)</param>
-		/// <returns>User's reviews.</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetUserReviewsAsync(string username, int page);
+        /// <summary>
+        /// Returns information about user's friends with given username.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="page">Index of the page.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Information about user's friends with given username.</returns>
+        Task<PaginatedJikanResponse<ICollection<Friend>>> GetUserFriendsAsync(string username, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns user's recommendations.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>User's recommendations.</returns>
-		Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetUserRecommendationsAsync(string username);
+        /// <summary>
+        /// Returns entries on user's anime list.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Entries on user's anime list.</returns>
+        Task<BaseJikanResponse<ICollection<AnimeListEntry>>> GetUserAnimeListAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns user's recommendations.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <param name="page">Index of page folding 10 records of top ranging (e.g. 1 will return first 10 records, 2 will return record from 11 to 21 etc.)</param>
-		/// <returns>User's recommendations.</returns>
-		Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetUserRecommendationsAsync(string username, int page);
+        /// <summary>
+        /// Returns entries on user's anime list.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="page">Index of page folding 300 records of top ranging (e.g. 1 will return first 300 records, 2 will return record from 301 to 600 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Entries on user's anime list.</returns>
+        Task<BaseJikanResponse<ICollection<AnimeListEntry>>> GetUserAnimeListAsync(string username, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns user's clubs.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>User's clubs.</returns>
-		Task<PaginatedJikanResponse<ICollection<MalUrl>>> GetUserClubsAsync(string username);
+        /// <summary>
+        /// Returns entries on user's manga list.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Entries on user's manga list.</returns>
+        Task<BaseJikanResponse<ICollection<MangaListEntry>>> GetUserMangaListAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns user's clubs.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <param name="page">Index of page folding 10 records of top ranging (e.g. 1 will return first 10 records, 2 will return record from 11 to 21 etc.)</param>
-		/// <returns>User's clubs.</returns>
-		Task<PaginatedJikanResponse<ICollection<MalUrl>>> GetUserClubsAsync(string username, int page);
-		
-		/// <summary>
-		/// Returns collection of external services links related to user.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>Collection of external services links related to anime.</returns>
-		Task<BaseJikanResponse<ICollection<ExternalLink>>> GetUserExternalLinksAsync(string username);
-		
-		/// <summary>
-		/// Returns user with additional data.
-		/// </summary>
-		/// <param name="username">Username.</param>
-		/// <returns>User profile with additional data.</returns>
-		Task<BaseJikanResponse<UserFull>> GetUserFullDataAsync(string username);
+        /// <summary>
+        /// Returns entries on user's manga list.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="page">Index of page folding 300 records of top ranging (e.g. 1 will return first 300 records, 2 will return record from 301 to 600 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Entries on user's manga list.</returns>
+        Task<BaseJikanResponse<ICollection<MangaListEntry>>> GetUserMangaListAsync(string username, int page, CancellationToken cancellationToken = default);
 
-		#endregion User requests
+        /// <summary>
+        /// Returns user's reviews.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>User's reviews.</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetUserReviewsAsync(string username, CancellationToken cancellationToken = default);
 
-		#region GetRandom requests
+        /// <summary>
+        /// Returns user's reviews.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="page">Index of page folding 10 records of top ranging (e.g. 1 will return first 10 records, 2 will return record from 11 to 21 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>User's reviews.</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetUserReviewsAsync(string username, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Gets random anime.
-		/// </summary>
-		/// <returns>Random anime</returns>
-		Task<BaseJikanResponse<Anime>> GetRandomAnimeAsync();
+        /// <summary>
+        /// Returns user's recommendations.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>User's recommendations.</returns>
+        Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetUserRecommendationsAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Gets random manga.
-		/// </summary>
-		/// <returns>Random manga</returns>
-		Task<BaseJikanResponse<Manga>> GetRandomMangaAsync();
+        /// <summary>
+        /// Returns user's recommendations.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="page">Index of page folding 10 records of top ranging (e.g. 1 will return first 10 records, 2 will return record from 11 to 21 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>User's recommendations.</returns>
+        Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetUserRecommendationsAsync(string username, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Gets random character.
-		/// </summary>
-		/// <returns>Random character</returns>
-		Task<BaseJikanResponse<Character>> GetRandomCharacterAsync();
+        /// <summary>
+        /// Returns user's clubs.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>User's clubs.</returns>
+        Task<PaginatedJikanResponse<ICollection<MalUrl>>> GetUserClubsAsync(string username, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Gets random person.
-		/// </summary>
-		/// <returns>Random person</returns>
-		Task<BaseJikanResponse<Person>> GetRandomPersonAsync();
+        /// <summary>
+        /// Returns user's clubs.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="page">Index of page folding 10 records of top ranging (e.g. 1 will return first 10 records, 2 will return record from 11 to 21 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>User's clubs.</returns>
+        Task<PaginatedJikanResponse<ICollection<MalUrl>>> GetUserClubsAsync(string username, int page, CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Gets random user.
-		/// </summary>
-		/// <returns>Random character</returns>
-		Task<BaseJikanResponse<UserProfile>> GetRandomUserAsync();
+        /// <summary>
+        /// Returns collection of external services links related to user.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of external services links related to anime.</returns>
+        Task<BaseJikanResponse<ICollection<ExternalLink>>> GetUserExternalLinksAsync(string username, CancellationToken cancellationToken = default);
 
-		#endregion
+        /// <summary>
+        /// Returns user with additional data.
+        /// </summary>
+        /// <param name="username">Username.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>User profile with additional data.</returns>
+        Task<BaseJikanResponse<UserFull>> GetUserFullDataAsync(string username, CancellationToken cancellationToken = default);
 
-		#region Recommendations requests
+        #endregion User requests
 
-		/// <summary>
-		/// Gets collection of recently added anime recommendations.
-		/// </summary>
-		/// <returns>Collection of recently added recommendations.r</returns>
-		Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentAnimeRecommendationsAsync();
-		
-		/// <summary>
-		/// Gets collection of recently added anime recommendations.
-		/// </summary>
-		/// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
-		/// <returns>Collection of recently added recommendations.r</returns>
-		Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentAnimeRecommendationsAsync(int page);
+        #region GetRandom requests
 
-		/// <summary>
-		/// Gets collection of recently added manga recommendations.
-		/// </summary>
-		/// <returns>Collection of recently added recommendations.r</returns>
-		Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentMangaRecommendationsAsync();
-		
-		/// <summary>
-		/// Gets collection of recently added manga recommendations.
-		/// </summary>
-		/// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
-		/// <returns>Collection of recently added recommendations.r</returns>
-		Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentMangaRecommendationsAsync(int page);
-		
-		#endregion
+        /// <summary>
+        /// Gets random anime.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Random anime</returns>
+        Task<BaseJikanResponse<Anime>> GetRandomAnimeAsync(CancellationToken cancellationToken = default);
 
-		#region Reviews requests
+        /// <summary>
+        /// Gets random manga.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Random manga</returns>
+        Task<BaseJikanResponse<Manga>> GetRandomMangaAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Gets collection of recently added anime reviews.
-		/// </summary>
-		/// <returns>Collection of recently added anime reviews</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentAnimeReviewsAsync();
-		
-		/// <summary>
-		/// Gets collection of recently added reviews.
-		/// </summary>
-		/// <param name="page">Index of page folding 50 records of top ranging (e.g. 1 will return first 50 records, 2 will return record from 51 to 100 etc.)</param>
-		/// <returns>Collection of recently added reviews</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentAnimeReviewsAsync(int page);
+        /// <summary>
+        /// Gets random character.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Random character</returns>
+        Task<BaseJikanResponse<Character>> GetRandomCharacterAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Gets collection of recently added manga reviews.
-		/// </summary>
-		/// <returns>Collection of recently added manga reviews</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentMangaReviewsAsync();
-		
-		/// <summary>
-		/// Gets collection of recently added manga reviews.
-		/// </summary>
-		/// <param name="page">Index of page folding 50 records of top ranging (e.g. 1 will return first 50 records, 2 will return record from 51 to 100 etc.)</param>
-		/// <returns>Collection of recently added manga reviews.</returns>
-		Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentMangaReviewsAsync(int page);
+        /// <summary>
+        /// Gets random person.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Random person</returns>
+        Task<BaseJikanResponse<Person>> GetRandomPersonAsync(CancellationToken cancellationToken = default);
 
-		#endregion
+        /// <summary>
+        /// Gets random user.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Random character</returns>
+        Task<BaseJikanResponse<UserProfile>> GetRandomUserAsync(CancellationToken cancellationToken = default);
 
-		#region Watch requests
+        #endregion
 
-		/// <summary>
-		/// Return collection of recently released episodes details.
-		/// </summary>
-		/// <returns>Collection of recently released episodes details..</returns>
-		Task<PaginatedJikanResponse<ICollection<WatchEpisode>>> GetWatchRecentEpisodesAsync();
-		
-		/// <summary>
-		/// Return collection of popular episodes details.
-		/// </summary>
-		/// <returns>Collection of popular episodes details.</returns>
-		Task<PaginatedJikanResponse<ICollection<WatchEpisode>>> GetWatchPopularEpisodesAsync();
+        #region Recommendations requests
 
-		/// <summary>
-		/// Return collection of recently released promos details.
-		/// </summary>
-		/// <returns>Collection of recently released promos details.</returns>
-		Task<PaginatedJikanResponse<ICollection<WatchPromoVideo>>> GetWatchRecentPromosAsync();
-		
-		/// <summary>
-		/// Return collection of popular promos details.
-		/// </summary>
-		/// <returns>Collection of popular promos details.</returns>
-		Task<PaginatedJikanResponse<ICollection<WatchPromoVideo>>> GetWatchPopularPromosAsync();
+        /// <summary>
+        /// Gets collection of recently added anime recommendations.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently added recommendations.r</returns>
+        Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentAnimeRecommendationsAsync(CancellationToken cancellationToken = default);
 
-		#endregion Watch requests
+        /// <summary>
+        /// Gets collection of recently added anime recommendations.
+        /// </summary>
+        /// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently added recommendations.r</returns>
+        Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentAnimeRecommendationsAsync(int page, CancellationToken cancellationToken = default);
 
-		#region Search requests
+        /// <summary>
+        /// Gets collection of recently added manga recommendations.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently added recommendations.r</returns>
+        Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentMangaRecommendationsAsync(CancellationToken cancellationToken = default);
 
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="query">Search query.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> SearchAnimeAsync(string query);
-		
+        /// <summary>
+        /// Gets collection of recently added manga recommendations.
+        /// </summary>
+        /// <param name="page">Index of page folding 100 records of top ranging (e.g. 1 will return first 100 records, 2 will return record from 101 to 200 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently added recommendations.r</returns>
+        Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentMangaRecommendationsAsync(int page, CancellationToken cancellationToken = default);
+
+        #endregion
+
+        #region Reviews requests
+
+        /// <summary>
+        /// Gets collection of recently added anime reviews.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently added anime reviews</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentAnimeReviewsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets collection of recently added reviews.
+        /// </summary>
+        /// <param name="page">Index of page folding 50 records of top ranging (e.g. 1 will return first 50 records, 2 will return record from 51 to 100 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently added reviews</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentAnimeReviewsAsync(int page, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets collection of recently added manga reviews.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently added manga reviews</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentMangaReviewsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets collection of recently added manga reviews.
+        /// </summary>
+        /// <param name="page">Index of page folding 50 records of top ranging (e.g. 1 will return first 50 records, 2 will return record from 51 to 100 etc.)</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently added manga reviews.</returns>
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentMangaReviewsAsync(int page, CancellationToken cancellationToken = default);
+
+        #endregion
+
+        #region Watch requests
+
+        /// <summary>
+        /// Return collection of recently released episodes details.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently released episodes details..</returns>
+        Task<PaginatedJikanResponse<ICollection<WatchEpisode>>> GetWatchRecentEpisodesAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Return collection of popular episodes details.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of popular episodes details.</returns>
+        Task<PaginatedJikanResponse<ICollection<WatchEpisode>>> GetWatchPopularEpisodesAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Return collection of recently released promos details.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of recently released promos details.</returns>
+        Task<PaginatedJikanResponse<ICollection<WatchPromoVideo>>> GetWatchRecentPromosAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Return collection of popular promos details.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Collection of popular promos details.</returns>
+        Task<PaginatedJikanResponse<ICollection<WatchPromoVideo>>> GetWatchPopularPromosAsync(CancellationToken cancellationToken = default);
+
+        #endregion Watch requests
+
+        #region Search requests
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> SearchAnimeAsync(string query, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="searchConfig">Additional configuration for advanced search.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<Anime>>> SearchAnimeAsync(AnimeSearchConfig searchConfig, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<Manga>>> SearchMangaAsync(string query, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="searchConfig">Additional configuration for advanced search.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<Manga>>> SearchMangaAsync(MangaSearchConfig searchConfig, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<Person>>> SearchPersonAsync(string query, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="searchConfig">Additional configuration for advanced search.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<Person>>> SearchPersonAsync(PersonSearchConfig searchConfig, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<Character>>> SearchCharacterAsync(string query, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="searchConfig">Additional configuration for advanced search.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<Character>>> SearchCharacterAsync(CharacterSearchConfig searchConfig, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<UserMetadata>>> SearchUserAsync(string query, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="searchConfig">Additional configuration for advanced search.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<UserMetadata>>> SearchUserAsync(UserSearchConfig searchConfig, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns list of results related to search.
+        /// </summary>
+        /// <param name="query">Search query.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>List of result related to search query.</returns>
+        Task<PaginatedJikanResponse<ICollection<Club>>> SearchClubAsync(string query, CancellationToken cancellationToken = default);
+
 		/// <summary>
 		/// Returns list of results related to search.
 		/// </summary>
 		/// <param name="searchConfig">Additional configuration for advanced search.</param>
+		/// <param name="cancellationToken">Cancellation token.</param>
 		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Anime>>> SearchAnimeAsync(AnimeSearchConfig searchConfig);
-		
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="query">Search query.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Manga>>> SearchMangaAsync(string query);
-		
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="searchConfig">Additional configuration for advanced search.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Manga>>> SearchMangaAsync(MangaSearchConfig searchConfig);
-		
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="query">Search query.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Person>>> SearchPersonAsync(string query);
-
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="searchConfig">Additional configuration for advanced search.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Person>>> SearchPersonAsync(PersonSearchConfig searchConfig);
-
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="query">Search query.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Character>>> SearchCharacterAsync(string query);
-
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="searchConfig">Additional configuration for advanced search.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Character>>> SearchCharacterAsync(CharacterSearchConfig searchConfig);
-		
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="query">Search query.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<UserMetadata>>> SearchUserAsync(string query);
-
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="searchConfig">Additional configuration for advanced search.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<UserMetadata>>> SearchUserAsync(UserSearchConfig searchConfig);
-		
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="query">Search query.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Club>>> SearchClubAsync(string query);
-
-		/// <summary>
-		/// Returns list of results related to search.
-		/// </summary>
-		/// <param name="searchConfig">Additional configuration for advanced search.</param>
-		/// <returns>List of result related to search query.</returns>
-		Task<PaginatedJikanResponse<ICollection<Club>>> SearchClubAsync(ClubSearchConfig searchConfig);
+		Task<PaginatedJikanResponse<ICollection<Club>>> SearchClubAsync(ClubSearchConfig searchConfig, CancellationToken cancellationToken = default);
 
 		#endregion Search requests
 	}

--- a/JikanDotNet/Jikan.cs
+++ b/JikanDotNet/Jikan.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace JikanDotNet
@@ -48,23 +49,24 @@ namespace JikanDotNet
 			_httpClient = httpClient ?? DefaultHttpClientProvider.GetDefaultHttpClient();
 		}
 
-		#endregion Constructors
+        #endregion Constructors
 
-		#region Private Methods
+        #region Private Methods
 
-		/// <summary>
-		/// Basic method for handling requests and responses from endpoint.
-		/// </summary>
-		/// <typeparam name="T">Class type received from GET requests.</typeparam>
-		/// <param name="routeSections">Arguments building endpoint.</param>
-		/// <returns>Requested object if successful, null otherwise.</returns>
-		private async Task<T> ExecuteGetRequestAsync<T>(ICollection<string> routeSections) where T : class
+        /// <summary>
+        /// Basic method for handling requests and responses from endpoint.
+        /// </summary>
+        /// <typeparam name="T">Class type received from GET requests.</typeparam>
+        /// <param name="routeSections">Arguments building endpoint.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Requested object if successful, null otherwise.</returns>
+        private async Task<T> ExecuteGetRequestAsync<T>(ICollection<string> routeSections, CancellationToken cancellationToken = default) where T : class
 		{
 			T returnedObject = null;
 			var requestUrl = string.Join("/", routeSections);
 			try
 			{
-				using var response = await _httpClient.GetAsync(requestUrl);
+				using var response = await _httpClient.GetAsync(requestUrl, cancellationToken);
 				if (response.IsSuccessStatusCode)
 				{
 					var json = await response.Content.ReadAsStringAsync();
@@ -95,207 +97,207 @@ namespace JikanDotNet
 		#region Anime methods
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<Anime>> GetAnimeAsync(long id)
+		public async Task<BaseJikanResponse<Anime>> GetAnimeAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString() };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Anime>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Anime>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<AnimeCharacter>>> GetAnimeCharactersAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<AnimeCharacter>>> GetAnimeCharactersAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Characters };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<AnimeCharacter>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<AnimeCharacter>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<AnimeStaffPosition>>> GetAnimeStaffAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<AnimeStaffPosition>>> GetAnimeStaffAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Staff };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<AnimeStaffPosition>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<AnimeStaffPosition>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<AnimeEpisode>>> GetAnimeEpisodesAsync(long id, int page)
+		public async Task<PaginatedJikanResponse<ICollection<AnimeEpisode>>> GetAnimeEpisodesAsync(long id, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Episodes + $"?page={page}" };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<AnimeEpisode>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<AnimeEpisode>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<AnimeEpisode>>> GetAnimeEpisodesAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<AnimeEpisode>>> GetAnimeEpisodesAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Episodes };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<AnimeEpisode>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<AnimeEpisode>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<AnimeEpisode>> GetAnimeEpisodeAsync(long animeId, int episodeId)
+		public async Task<BaseJikanResponse<AnimeEpisode>> GetAnimeEpisodeAsync(long animeId, int episodeId, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(animeId, nameof(animeId));
 			Guard.IsGreaterThanZero(episodeId, nameof(episodeId));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, animeId.ToString(), JikanEndpointConsts.Episodes, episodeId.ToString() };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeEpisode>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeEpisode>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<News>>> GetAnimeNewsAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<News>>> GetAnimeNewsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.News };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<News>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<News>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<News>>> GetAnimeNewsAsync(long id, int page)
+		public async Task<PaginatedJikanResponse<ICollection<News>>> GetAnimeNewsAsync(long id, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.News + $"?page={page}" };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<News>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<News>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ForumTopic>>> GetAnimeForumTopicsAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ForumTopic>>> GetAnimeForumTopicsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Forum };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ForumTopic>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ForumTopic>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ForumTopic>>> GetAnimeForumTopicsAsync(long id, ForumTopicType type)
+		public async Task<BaseJikanResponse<ICollection<ForumTopic>>> GetAnimeForumTopicsAsync(long id, ForumTopicType type, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			Guard.IsValidEnum(type, nameof(type));
 
 			var queryParams = $"?filter={type.GetDescription()}";
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Forum + queryParams };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ForumTopic>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ForumTopic>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<AnimeVideos>> GetAnimeVideosAsync(long id)
+		public async Task<BaseJikanResponse<AnimeVideos>> GetAnimeVideosAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Videos };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeVideos>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeVideos>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ImagesSet>>> GetAnimePicturesAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ImagesSet>>> GetAnimePicturesAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Pictures };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ImagesSet>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ImagesSet>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<AnimeStatistics>> GetAnimeStatisticsAsync(long id)
+		public async Task<BaseJikanResponse<AnimeStatistics>> GetAnimeStatisticsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Statistics };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeStatistics>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeStatistics>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<MoreInfo>> GetAnimeMoreInfoAsync(long id)
+		public async Task<BaseJikanResponse<MoreInfo>> GetAnimeMoreInfoAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.MoreInfo };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<MoreInfo>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<MoreInfo>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<Recommendation>>> GetAnimeRecommendationsAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<Recommendation>>> GetAnimeRecommendationsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Recommendations };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Recommendation>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Recommendation>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>> GetAnimeUserUpdatesAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>> GetAnimeUserUpdatesAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.UserUpdates };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>> GetAnimeUserUpdatesAsync(long id, int page)
+		public async Task<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>> GetAnimeUserUpdatesAsync(long id, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			Guard.IsGreaterThanZero(page, nameof(page));
 
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.UserUpdates + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<AnimeUserUpdate>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetAnimeReviewsAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetAnimeReviewsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Reviews };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetAnimeReviewsAsync(long id, int page)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetAnimeReviewsAsync(long id, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			Guard.IsGreaterThanZero(page, nameof(page));
 
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Reviews + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<RelatedEntry>>> GetAnimeRelationsAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<RelatedEntry>>> GetAnimeRelationsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Relations };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<RelatedEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<RelatedEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<AnimeThemes>> GetAnimeThemesAsync(long id)
+		public async Task<BaseJikanResponse<AnimeThemes>> GetAnimeThemesAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Themes };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeThemes>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeThemes>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetAnimeExternalLinksAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetAnimeExternalLinksAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.External };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetAnimeStreamingLinksAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetAnimeStreamingLinksAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Streaming };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<AnimeFull>> GetAnimeFullDataAsync(long id)
+		public async Task<BaseJikanResponse<AnimeFull>> GetAnimeFullDataAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString(), JikanEndpointConsts.Full };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeFull>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<AnimeFull>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Anime methods
@@ -303,51 +305,51 @@ namespace JikanDotNet
 		#region Character methods
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<Character>> GetCharacterAsync(long id)
+		public async Task<BaseJikanResponse<Character>> GetCharacterAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Characters, id.ToString() };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Character>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Character>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<CharacterAnimeographyEntry>>> GetCharacterAnimeAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<CharacterAnimeographyEntry>>> GetCharacterAnimeAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Characters, id.ToString(), JikanEndpointConsts.Anime };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<CharacterAnimeographyEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<CharacterAnimeographyEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<CharacterMangaographyEntry>>> GetCharacterMangaAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<CharacterMangaographyEntry>>> GetCharacterMangaAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Characters, id.ToString(), JikanEndpointConsts.Manga };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<CharacterMangaographyEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<CharacterMangaographyEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<VoiceActorEntry>>> GetCharacterVoiceActorsAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<VoiceActorEntry>>> GetCharacterVoiceActorsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Characters, id.ToString(), JikanEndpointConsts.Voices };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<VoiceActorEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<VoiceActorEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ImagesSet>>> GetCharacterPicturesAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ImagesSet>>> GetCharacterPicturesAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Characters, id.ToString(), JikanEndpointConsts.Pictures };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ImagesSet>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ImagesSet>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<CharacterFull>> GetCharacterFullDataAsync(long id)
+		public async Task<BaseJikanResponse<CharacterFull>> GetCharacterFullDataAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Characters, id.ToString(), JikanEndpointConsts.Full };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<CharacterFull>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<CharacterFull>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Character methods
@@ -355,129 +357,129 @@ namespace JikanDotNet
 		#region Manga methods
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<Manga>> GetMangaAsync(long id)
+		public async Task<BaseJikanResponse<Manga>> GetMangaAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString() };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Manga>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Manga>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<MangaCharacter>>> GetMangaCharactersAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<MangaCharacter>>> GetMangaCharactersAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Characters };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<MangaCharacter>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<MangaCharacter>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<News>>> GetMangaNewsAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<News>>> GetMangaNewsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.News };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<News>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<News>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<News>>> GetMangaNewsAsync(long id, int page)
+		public async Task<PaginatedJikanResponse<ICollection<News>>> GetMangaNewsAsync(long id, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			Guard.IsGreaterThanZero(page, nameof(page));
 
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.News + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<News>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<News>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ForumTopic>>> GetMangaForumTopicsAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ForumTopic>>> GetMangaForumTopicsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Forum };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ForumTopic>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ForumTopic>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ImagesSet>>> GetMangaPicturesAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ImagesSet>>> GetMangaPicturesAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Pictures };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ImagesSet>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ImagesSet>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<MangaStatistics>> GetMangaStatisticsAsync(long id)
+		public async Task<BaseJikanResponse<MangaStatistics>> GetMangaStatisticsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Statistics };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<MangaStatistics>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<MangaStatistics>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<MoreInfo>> GetMangaMoreInfoAsync(long id)
+		public async Task<BaseJikanResponse<MoreInfo>> GetMangaMoreInfoAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.MoreInfo };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<MoreInfo>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<MoreInfo>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<MangaUserUpdate>>> GetMangaUserUpdatesAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<MangaUserUpdate>>> GetMangaUserUpdatesAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.UserUpdates };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<MangaUserUpdate>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<MangaUserUpdate>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<MangaUserUpdate>>> GetMangaUserUpdatesAsync(long id, int page)
+		public async Task<PaginatedJikanResponse<ICollection<MangaUserUpdate>>> GetMangaUserUpdatesAsync(long id, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			Guard.IsGreaterThanZero(page, nameof(page));
 
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.UserUpdates + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<MangaUserUpdate>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<MangaUserUpdate>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<Recommendation>>> GetMangaRecommendationsAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<Recommendation>>> GetMangaRecommendationsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Recommendations };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Recommendation>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Recommendation>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Reviews };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<RelatedEntry>>> GetMangaRelationsAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<RelatedEntry>>> GetMangaRelationsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Relations };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<RelatedEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<RelatedEntry>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetMangaExternalLinksAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetMangaExternalLinksAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.External };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<MangaFull>> GetMangaFullDataAsync(long id)
+		public async Task<BaseJikanResponse<MangaFull>> GetMangaFullDataAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Full };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<MangaFull>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<MangaFull>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Manga methods
@@ -485,51 +487,51 @@ namespace JikanDotNet
 		#region Person methods
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<Person>> GetPersonAsync(long id)
+		public async Task<BaseJikanResponse<Person>> GetPersonAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.People, id.ToString() };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Person>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Person>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<PersonAnimeographyEntry>>> GetPersonAnimeAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<PersonAnimeographyEntry>>> GetPersonAnimeAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.People, id.ToString(), JikanEndpointConsts.Anime };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<PersonAnimeographyEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<PersonAnimeographyEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<PersonMangaographyEntry>>> GetPersonMangaAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<PersonMangaographyEntry>>> GetPersonMangaAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.People, id.ToString(), JikanEndpointConsts.Manga };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<PersonMangaographyEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<PersonMangaographyEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<VoiceActingRole>>> GetPersonVoiceActingRolesAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<VoiceActingRole>>> GetPersonVoiceActingRolesAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.People, id.ToString(), JikanEndpointConsts.Voices };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<VoiceActingRole>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<VoiceActingRole>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ImagesSet>>> GetPersonPicturesAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ImagesSet>>> GetPersonPicturesAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.People, id.ToString(), JikanEndpointConsts.Pictures };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ImagesSet>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ImagesSet>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<PersonFull>> GetPersonFullDataAsync(long id)
+		public async Task<BaseJikanResponse<PersonFull>> GetPersonFullDataAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.People, id.ToString(), JikanEndpointConsts.Full };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<PersonFull>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<PersonFull>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Person methods
@@ -537,62 +539,62 @@ namespace JikanDotNet
 		#region Season methods
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetSeasonAsync(int year, Season season)
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetSeasonAsync(int year, Season season, CancellationToken cancellationToken = default)
 		{
 			Guard.IsValid(x => x is >= 1000 and < 10000, year, nameof(year));
 			Guard.IsValidEnum(season, nameof(season));
 			var endpointParts = new[] { JikanEndpointConsts.Seasons, year.ToString(), season.GetDescription() };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetSeasonAsync(int year, Season season, int page)
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetSeasonAsync(int year, Season season, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsValid(x => x is >= 1000 and < 10000, year, nameof(year));
 			Guard.IsValidEnum(season, nameof(season));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Seasons, year.ToString(), season.GetDescription() + queryParams};
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<SeasonArchive>>> GetSeasonArchiveAsync()
+		public async Task<PaginatedJikanResponse<ICollection<SeasonArchive>>> GetSeasonArchiveAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Seasons };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<SeasonArchive>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<SeasonArchive>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetCurrentSeasonAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetCurrentSeasonAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Seasons, JikanEndpointConsts.Now };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetCurrentSeasonAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetCurrentSeasonAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Seasons, JikanEndpointConsts.Now + queryParams};
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetUpcomingSeasonAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetUpcomingSeasonAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Seasons, JikanEndpointConsts.Upcoming };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetUpcomingSeasonAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetUpcomingSeasonAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Seasons, JikanEndpointConsts.Upcoming + queryParams};
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Season methods
@@ -600,28 +602,28 @@ namespace JikanDotNet
 		#region Schedule methods
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Schedules };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Schedules + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(ScheduledDay scheduledDay)
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetScheduleAsync(ScheduledDay scheduledDay, CancellationToken cancellationToken = default)
 		{
 			Guard.IsValidEnum(scheduledDay, nameof(scheduledDay));
 			var queryParams = $"?filter={scheduledDay.GetDescription()}";
 			var endpointParts = new[] { JikanEndpointConsts.Schedules + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Schedule methods
@@ -629,102 +631,102 @@ namespace JikanDotNet
 		#region Top methods
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Anime };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Anime + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(TopAnimeFilter filter)
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(TopAnimeFilter filter, CancellationToken cancellationToken = default)
 		{
 			Guard.IsValidEnum(filter, nameof(filter));
 			var queryParams = $"?filter={filter.GetDescription()}";
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Anime + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 		
         /// <inheritdoc />
-        public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(TopAnimeFilter filter, int page)
+        public async Task<PaginatedJikanResponse<ICollection<Anime>>> GetTopAnimeAsync(TopAnimeFilter filter, int page, CancellationToken cancellationToken = default)
         {
 	        Guard.IsValidEnum(filter, nameof(filter));
             Guard.IsGreaterThanZero(page, nameof(page));
             var queryParams = $"?page={page}&filter={filter.GetDescription()}";
             var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Anime + queryParams };
-            return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+            return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
         }
         
         /// <inheritdoc />
-        public async Task<PaginatedJikanResponse<ICollection<Manga>>> GetTopMangaAsync()
+        public async Task<PaginatedJikanResponse<ICollection<Manga>>> GetTopMangaAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Manga };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Manga>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Manga>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Manga>>> GetTopMangaAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Manga>>> GetTopMangaAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Manga + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Manga>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Manga>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Person>>> GetTopPeopleAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Person>>> GetTopPeopleAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.People };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Person>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Person>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Person>>> GetTopPeopleAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Person>>> GetTopPeopleAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.People + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Person>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Person>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Character>>> GetTopCharactersAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Character>>> GetTopCharactersAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Characters };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Character>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Character>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Character>>> GetTopCharactersAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Character>>> GetTopCharactersAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Characters + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Character>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Character>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetTopReviewsAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetTopReviewsAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Reviews };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetTopReviewsAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetTopReviewsAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.TopList, JikanEndpointConsts.Reviews + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Top methods
@@ -732,35 +734,35 @@ namespace JikanDotNet
 		#region Genre methods
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<Genre>>> GetAnimeGenresAsync()
+		public async Task<BaseJikanResponse<ICollection<Genre>>> GetAnimeGenresAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Genres, JikanEndpointConsts.Anime };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Genre>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Genre>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<Genre>>> GetAnimeGenresAsync(GenresFilter filter)
+		public async Task<BaseJikanResponse<ICollection<Genre>>> GetAnimeGenresAsync(GenresFilter filter, CancellationToken cancellationToken = default)
 		{
 			Guard.IsValidEnum(filter, nameof(filter));
 			var queryParams = $"?filter={filter.GetDescription()}";
 			var endpointParts = new[] { JikanEndpointConsts.Genres, JikanEndpointConsts.Anime + queryParams };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Genre>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Genre>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<Genre>>> GetMangaGenresAsync()
+		public async Task<BaseJikanResponse<ICollection<Genre>>> GetMangaGenresAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Genres, JikanEndpointConsts.Manga };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Genre>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Genre>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<Genre>>> GetMangaGenresAsync(GenresFilter filter)
+		public async Task<BaseJikanResponse<ICollection<Genre>>> GetMangaGenresAsync(GenresFilter filter, CancellationToken cancellationToken = default)
 		{
 			Guard.IsValidEnum(filter, nameof(filter));
 			var queryParams = $"?filter={filter.GetDescription()}";
 			var endpointParts = new[] { JikanEndpointConsts.Genres, JikanEndpointConsts.Manga + queryParams };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Genre>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<Genre>>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Genre methods
@@ -768,43 +770,43 @@ namespace JikanDotNet
 		#region Producer methods
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Producer>>> GetProducersAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Producer>>> GetProducersAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Producers };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Producer>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Producer>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Producer>>> GetProducersAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Producer>>> GetProducersAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Producers + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Producer>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Producer>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<Producer>> GetProducerAsync(long id)
+		public async Task<BaseJikanResponse<Producer>> GetProducerAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Producers, id.ToString() };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Producer>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Producer>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetProducerExternalLinksAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetProducerExternalLinksAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Producers, id.ToString(), JikanEndpointConsts.External };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ProducerFull>> GetProducerFullDataAsync(long id)
+		public async Task<BaseJikanResponse<ProducerFull>> GetProducerFullDataAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Producers, id.ToString(), JikanEndpointConsts.Full };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ProducerFull>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ProducerFull>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Producer methods
@@ -812,19 +814,19 @@ namespace JikanDotNet
 		#region Magazine methods
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Magazine>>> GetMagazinesAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Magazine>>> GetMagazinesAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Magazines };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Magazine>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Magazine>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Magazine>>> GetMagazinesAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Magazine>>> GetMagazinesAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Magazines + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Magazine>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Magazine>>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Magazine methods
@@ -832,45 +834,45 @@ namespace JikanDotNet
 		#region Club methods
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<Club>> GetClubAsync(long id)
+		public async Task<BaseJikanResponse<Club>> GetClubAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Clubs, id.ToString() };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Club>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Club>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<ClubMember>>> GetClubMembersAsync(long id)
+		public async Task<PaginatedJikanResponse<ICollection<ClubMember>>> GetClubMembersAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Clubs, id.ToString(), JikanEndpointConsts.Members };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<ClubMember>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<ClubMember>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<ClubMember>>> GetClubMembersAsync(long id, int page)
+		public async Task<PaginatedJikanResponse<ICollection<ClubMember>>> GetClubMembersAsync(long id, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Clubs, id.ToString(), JikanEndpointConsts.Members + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<ClubMember>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<ClubMember>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ClubStaff>>> GetClubStaffAsync(long id)
+		public async Task<BaseJikanResponse<ICollection<ClubStaff>>> GetClubStaffAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Clubs, id.ToString(), JikanEndpointConsts.Staff };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ClubStaff>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ClubStaff>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ClubRelations>> GetClubRelationsAsync(long id)
+		public async Task<BaseJikanResponse<ClubRelations>> GetClubRelationsAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Clubs, id.ToString(), JikanEndpointConsts.Relations };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ClubRelations>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ClubRelations>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Club methods
@@ -878,185 +880,185 @@ namespace JikanDotNet
 		#region User methods
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<UserProfile>> GetUserProfileAsync(string username)
+		public async Task<BaseJikanResponse<UserProfile>> GetUserProfileAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<UserProfile>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<UserProfile>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<UserStatistics>> GetUserStatisticsAsync(string username)
+		public async Task<BaseJikanResponse<UserStatistics>> GetUserStatisticsAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Statistics };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<UserStatistics>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<UserStatistics>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<UserFavorites>> GetUserFavoritesAsync(string username)
+		public async Task<BaseJikanResponse<UserFavorites>> GetUserFavoritesAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Favorites };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<UserFavorites>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<UserFavorites>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<UserUpdates>> GetUserUpdatesAsync(string username)
+		public async Task<BaseJikanResponse<UserUpdates>> GetUserUpdatesAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.UserUpdates };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<UserUpdates>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<UserUpdates>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<UserAbout>> GetUserAboutAsync(string username)
+		public async Task<BaseJikanResponse<UserAbout>> GetUserAboutAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.About };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<UserAbout>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<UserAbout>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<HistoryEntry>>> GetUserHistoryAsync(string username)
+		public async Task<BaseJikanResponse<ICollection<HistoryEntry>>> GetUserHistoryAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.History };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<HistoryEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<HistoryEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<HistoryEntry>>> GetUserHistoryAsync(string username, UserHistoryExtension historyExtension)
+		public async Task<BaseJikanResponse<ICollection<HistoryEntry>>> GetUserHistoryAsync(string username, UserHistoryExtension historyExtension, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsValidEnum(historyExtension, nameof(historyExtension));
 			var queryParams = $"?filter={historyExtension.GetDescription()}";
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.History + queryParams };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<HistoryEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<HistoryEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<AnimeListEntry>>> GetUserAnimeListAsync(string username)
+		public async Task<BaseJikanResponse<ICollection<AnimeListEntry>>> GetUserAnimeListAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.AnimeList };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<AnimeListEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<AnimeListEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<AnimeListEntry>>> GetUserAnimeListAsync(string username, int page)
+		public async Task<BaseJikanResponse<ICollection<AnimeListEntry>>> GetUserAnimeListAsync(string username, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.AnimeList + queryParams };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<AnimeListEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<AnimeListEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<MangaListEntry>>> GetUserMangaListAsync(string username)
+		public async Task<BaseJikanResponse<ICollection<MangaListEntry>>> GetUserMangaListAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.MangaList };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<MangaListEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<MangaListEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<MangaListEntry>>> GetUserMangaListAsync(string username, int page)
+		public async Task<BaseJikanResponse<ICollection<MangaListEntry>>> GetUserMangaListAsync(string username, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.MangaList + queryParams };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<MangaListEntry>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<MangaListEntry>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Friend>>> GetUserFriendsAsync(string username)
+		public async Task<PaginatedJikanResponse<ICollection<Friend>>> GetUserFriendsAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Friends };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Friend>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Friend>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Friend>>> GetUserFriendsAsync(string username, int page)
+		public async Task<PaginatedJikanResponse<ICollection<Friend>>> GetUserFriendsAsync(string username, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Friends + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Friend>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Friend>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetUserReviewsAsync(string username)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetUserReviewsAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Reviews };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetUserReviewsAsync(string username, int page)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetUserReviewsAsync(string username, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Reviews + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetUserRecommendationsAsync(string username)
+		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetUserRecommendationsAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Recommendations };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetUserRecommendationsAsync(string username, int page)
+		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetUserRecommendationsAsync(string username, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Recommendations + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<MalUrl>>> GetUserClubsAsync(string username)
+		public async Task<PaginatedJikanResponse<ICollection<MalUrl>>> GetUserClubsAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Clubs };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<MalUrl>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<MalUrl>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<MalUrl>>> GetUserClubsAsync(string username, int page)
+		public async Task<PaginatedJikanResponse<ICollection<MalUrl>>> GetUserClubsAsync(string username, int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Clubs + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<MalUrl>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<MalUrl>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetUserExternalLinksAsync(string username)
+		public async Task<BaseJikanResponse<ICollection<ExternalLink>>> GetUserExternalLinksAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.External };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<ICollection<ExternalLink>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public async Task<BaseJikanResponse<UserFull>> GetUserFullDataAsync(string username)
+		public async Task<BaseJikanResponse<UserFull>> GetUserFullDataAsync(string username, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNullOrWhiteSpace(username, nameof(username));
 			var endpointParts = new[] { JikanEndpointConsts.Users, username, JikanEndpointConsts.Full };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<UserFull>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<UserFull>>(endpointParts, cancellationToken);
 		}
 
 		#endregion User methods
@@ -1064,38 +1066,38 @@ namespace JikanDotNet
 		#region GetRandom methods
 
 		/// <inheritdoc/>
-		public async Task<BaseJikanResponse<Anime>> GetRandomAnimeAsync()
+		public async Task<BaseJikanResponse<Anime>> GetRandomAnimeAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Random, JikanEndpointConsts.Anime };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Anime>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Anime>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc/>
-		public async Task<BaseJikanResponse<Manga>> GetRandomMangaAsync()
+		public async Task<BaseJikanResponse<Manga>> GetRandomMangaAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Random, JikanEndpointConsts.Manga };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Manga>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Manga>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc/>
-		public async Task<BaseJikanResponse<Character>> GetRandomCharacterAsync()
+		public async Task<BaseJikanResponse<Character>> GetRandomCharacterAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Random, JikanEndpointConsts.Characters };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Character>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Character>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc/>
-		public async Task<BaseJikanResponse<Person>> GetRandomPersonAsync()
+		public async Task<BaseJikanResponse<Person>> GetRandomPersonAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Random, JikanEndpointConsts.People };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<Person>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<Person>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc/>
-		public async Task<BaseJikanResponse<UserProfile>> GetRandomUserAsync()
+		public async Task<BaseJikanResponse<UserProfile>> GetRandomUserAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Random, JikanEndpointConsts.Users };
-			return await ExecuteGetRequestAsync<BaseJikanResponse<UserProfile>>(endpointParts);
+			return await ExecuteGetRequestAsync<BaseJikanResponse<UserProfile>>(endpointParts, cancellationToken);
 		}
 
 		#endregion GetRandom methods
@@ -1103,31 +1105,31 @@ namespace JikanDotNet
 		#region Watch methods
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<WatchEpisode>>> GetWatchRecentEpisodesAsync()
+		public async Task<PaginatedJikanResponse<ICollection<WatchEpisode>>> GetWatchRecentEpisodesAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Watch, JikanEndpointConsts.Episodes };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<WatchEpisode>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<WatchEpisode>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<WatchEpisode>>> GetWatchPopularEpisodesAsync()
+		public async Task<PaginatedJikanResponse<ICollection<WatchEpisode>>> GetWatchPopularEpisodesAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Watch, JikanEndpointConsts.Episodes, JikanEndpointConsts.Popular };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<WatchEpisode>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<WatchEpisode>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<WatchPromoVideo>>> GetWatchRecentPromosAsync()
+		public async Task<PaginatedJikanResponse<ICollection<WatchPromoVideo>>> GetWatchRecentPromosAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Watch, JikanEndpointConsts.Promos };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<WatchPromoVideo>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<WatchPromoVideo>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<WatchPromoVideo>>> GetWatchPopularPromosAsync()
+		public async Task<PaginatedJikanResponse<ICollection<WatchPromoVideo>>> GetWatchPopularPromosAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Watch, JikanEndpointConsts.Promos, JikanEndpointConsts.Popular };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<WatchPromoVideo>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<WatchPromoVideo>>>(endpointParts, cancellationToken);
 		}
 		
 		#endregion
@@ -1135,35 +1137,35 @@ namespace JikanDotNet
 		#region Reviews methods
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentAnimeReviewsAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentAnimeReviewsAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Reviews, JikanEndpointConsts.Anime };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentAnimeReviewsAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentAnimeReviewsAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Reviews, JikanEndpointConsts.Anime + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentMangaReviewsAsync()
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentMangaReviewsAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Reviews, JikanEndpointConsts.Manga };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentMangaReviewsAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetRecentMangaReviewsAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Reviews, JikanEndpointConsts.Manga + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 		
 		#endregion
@@ -1171,35 +1173,35 @@ namespace JikanDotNet
 		#region Recommendations methods
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentAnimeRecommendationsAsync()
+		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentAnimeRecommendationsAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Recommendations, JikanEndpointConsts.Anime };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentAnimeRecommendationsAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentAnimeRecommendationsAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Recommendations, JikanEndpointConsts.Anime + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentMangaRecommendationsAsync()
+		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentMangaRecommendationsAsync(CancellationToken cancellationToken = default)
 		{
 			var endpointParts = new[] { JikanEndpointConsts.Recommendations, JikanEndpointConsts.Manga };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentMangaRecommendationsAsync(int page)
+		public async Task<PaginatedJikanResponse<ICollection<UserRecommendation>>> GetRecentMangaRecommendationsAsync(int page, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(page, nameof(page));
 			var queryParams = $"?page={page}";
 			var endpointParts = new[] { JikanEndpointConsts.Recommendations, JikanEndpointConsts.Manga + queryParams };
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserRecommendation>>>(endpointParts, cancellationToken);
 		}
 		
 		#endregion
@@ -1209,73 +1211,73 @@ namespace JikanDotNet
 		
 		
 		/// <inheritdoc />
-		public Task<PaginatedJikanResponse<ICollection<Anime>>> SearchAnimeAsync(string query)
-			=> SearchAnimeAsync(new AnimeSearchConfig {Query = query});
+		public Task<PaginatedJikanResponse<ICollection<Anime>>> SearchAnimeAsync(string query, CancellationToken cancellationToken = default)
+			=> SearchAnimeAsync(new AnimeSearchConfig {Query = query}, cancellationToken);
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Anime>>> SearchAnimeAsync(AnimeSearchConfig searchConfig)
+		public async Task<PaginatedJikanResponse<ICollection<Anime>>> SearchAnimeAsync(AnimeSearchConfig searchConfig, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNull(searchConfig, nameof(searchConfig));
 			var endpointParts = new[] { JikanEndpointConsts.Anime + searchConfig.ConfigToString()};
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Anime>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public Task<PaginatedJikanResponse<ICollection<Manga>>> SearchMangaAsync(string query)
-			=> SearchMangaAsync(new MangaSearchConfig {Query = query});
+		public Task<PaginatedJikanResponse<ICollection<Manga>>> SearchMangaAsync(string query, CancellationToken cancellationToken = default)
+			=> SearchMangaAsync(new MangaSearchConfig {Query = query}, cancellationToken);
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Manga>>> SearchMangaAsync(MangaSearchConfig searchConfig)
+		public async Task<PaginatedJikanResponse<ICollection<Manga>>> SearchMangaAsync(MangaSearchConfig searchConfig, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNull(searchConfig, nameof(searchConfig));
 			var endpointParts = new[] { JikanEndpointConsts.Manga + searchConfig.ConfigToString()};
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Manga>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Manga>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public Task<PaginatedJikanResponse<ICollection<Person>>> SearchPersonAsync(string query)
-			=> SearchPersonAsync(new PersonSearchConfig {Query = query});
+		public Task<PaginatedJikanResponse<ICollection<Person>>> SearchPersonAsync(string query, CancellationToken cancellationToken = default)
+			=> SearchPersonAsync(new PersonSearchConfig {Query = query}, cancellationToken);
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Person>>> SearchPersonAsync(PersonSearchConfig searchConfig)
+		public async Task<PaginatedJikanResponse<ICollection<Person>>> SearchPersonAsync(PersonSearchConfig searchConfig, CancellationToken cancellationToken = default)
 		{	
 			Guard.IsNotNull(searchConfig, nameof(searchConfig));
 			var endpointParts = new[] { JikanEndpointConsts.People + searchConfig.ConfigToString()};
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Person>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Person>>>(endpointParts, cancellationToken);
 		}
 
 		/// <inheritdoc />
-		public Task<PaginatedJikanResponse<ICollection<Character>>> SearchCharacterAsync(string query)
-			=> SearchCharacterAsync(new CharacterSearchConfig {Query = query});
+		public Task<PaginatedJikanResponse<ICollection<Character>>> SearchCharacterAsync(string query, CancellationToken cancellationToken = default)
+			=> SearchCharacterAsync(new CharacterSearchConfig {Query = query}, cancellationToken);
 		
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Character>>> SearchCharacterAsync(CharacterSearchConfig searchConfig)
+		public async Task<PaginatedJikanResponse<ICollection<Character>>> SearchCharacterAsync(CharacterSearchConfig searchConfig, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNull(searchConfig, nameof(searchConfig));
 			var endpointParts = new[] { JikanEndpointConsts.Characters + searchConfig.ConfigToString()};
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Character>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Character>>>(endpointParts, cancellationToken);
 		}
 	
 		/// <inheritdoc />
-		public  Task<PaginatedJikanResponse<ICollection<UserMetadata>>> SearchUserAsync(string query) => SearchUserAsync(new UserSearchConfig {Query = query});
+		public  Task<PaginatedJikanResponse<ICollection<UserMetadata>>> SearchUserAsync(string query, CancellationToken cancellationToken = default) => SearchUserAsync(new UserSearchConfig {Query = query}, cancellationToken);
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<UserMetadata>>> SearchUserAsync(UserSearchConfig searchConfig)
+		public async Task<PaginatedJikanResponse<ICollection<UserMetadata>>> SearchUserAsync(UserSearchConfig searchConfig, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNull(searchConfig, nameof(searchConfig));
 			var endpointParts = new[] {JikanEndpointConsts.Users + searchConfig.ConfigToString()};
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserMetadata>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<UserMetadata>>>(endpointParts, cancellationToken);
 		}
 		
 		/// <inheritdoc />
-		public  Task<PaginatedJikanResponse<ICollection<Club>>> SearchClubAsync(string query) => SearchClubAsync(new ClubSearchConfig {Query = query});
+		public  Task<PaginatedJikanResponse<ICollection<Club>>> SearchClubAsync(string query, CancellationToken cancellationToken = default) => SearchClubAsync(new ClubSearchConfig {Query = query}, cancellationToken);
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Club>>> SearchClubAsync(ClubSearchConfig searchConfig)
+		public async Task<PaginatedJikanResponse<ICollection<Club>>> SearchClubAsync(ClubSearchConfig searchConfig, CancellationToken cancellationToken = default)
 		{
 			Guard.IsNotNull(searchConfig, nameof(searchConfig));
 			var endpointParts = new[] {JikanEndpointConsts.Users + searchConfig.ConfigToString()};
-			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Club>>>(endpointParts);
+			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Club>>>(endpointParts, cancellationToken);
 		}
 
 		#endregion Search methods


### PR DESCRIPTION
Hi,

I am working on an interactive UI application and had problems cancelling the HTTP requests immediately on a page switch. I have found no other way to cancel the request than to give the internal HttpGet a cancellation token. I thought this could help people in the future, so I edited all API calls to include a CancellationToken.

I tested it, and there shouldn't be any changes for people already working with the library.