### PR TITLE
Add `JsonConverter` attribute to JikanApiError.cs

### DIFF
--- a/JikanDotNet/Model/JikanApiError.cs
+++ b/JikanDotNet/Model/JikanApiError.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 namespace JikanDotNet
 {
 	/// <summary>
-	/// Class of error data returned in case http call was unsucessfull
+	/// Class of error data returned in case http call was unsuccessful
 	/// </summary>
 	public class JikanApiError
 	{
@@ -12,6 +12,7 @@ namespace JikanDotNet
 		/// Response code received from HttpResponseMessage.
 		/// </summary>
 		[JsonPropertyName("status")]
+		[JsonConverter(typeof(JsonStringEnumConverter))]
 		public HttpStatusCode Status { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
Without explicit enum conversion, it would throw a deserialization exception.

Before:
`Unhandled exception. JikanDotNet.Exceptions.JikanRequestException: Serialization failed.
Inner exception message: The JSON value could not be converted to System.Net.HttpStatusCode. Path: $.status | LineNumber: 0 | BytePositionInLine: 16.`

After:
`Unhandled exception. JikanDotNet.Exceptions.JikanRequestException: GET request failed. Status code: TooManyRequests Inner message: System.Net.Http.HttpConnectionResponseContent`