### PR TITLE
Include preliminary reviews from MAL

### DIFF
--- a/JikanDotNet.Test/MangaTests/GetMangaReviewsAsyncTests.cs
+++ b/JikanDotNet.Test/MangaTests/GetMangaReviewsAsyncTests.cs
@@ -44,5 +44,6 @@ namespace JikanDotNet.Tests.MangaTests
 				berserk.Data.First().Reactions.TotalReactions.Should().BeGreaterThan(1);
 			}
 		}
+
 	}
 }

--- a/JikanDotNet/Interfaces/IJikan.cs
+++ b/JikanDotNet/Interfaces/IJikan.cs
@@ -306,10 +306,10 @@ namespace JikanDotNet
         /// Returns collection of manga reviews.
         /// </summary>
         /// <param name="id">MAL id of manga.</param>
-        /// <param name="includePreliminary">Include Preliminary Reviews. Defaults to false.</param>
+        /// <param name="includePreliminary">Include Preliminary Reviews. Defaults to true.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Collection of manga reviews.</returns>
-        Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, bool includePreliminary = false, CancellationToken cancellationToken = default);
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, bool includePreliminary = true, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns collection of manga related entries.

--- a/JikanDotNet/Interfaces/IJikan.cs
+++ b/JikanDotNet/Interfaces/IJikan.cs
@@ -306,9 +306,10 @@ namespace JikanDotNet
         /// Returns collection of manga reviews.
         /// </summary>
         /// <param name="id">MAL id of manga.</param>
+        /// <param name="includePreliminary">Include Preliminary Reviews. Defaults to false.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Collection of manga reviews.</returns>
-        Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, CancellationToken cancellationToken = default);
+        Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, bool includePreliminary = false, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns collection of manga related entries.

--- a/JikanDotNet/Jikan.cs
+++ b/JikanDotNet/Jikan.cs
@@ -459,11 +459,16 @@ namespace JikanDotNet
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, bool includePreliminary = false, CancellationToken cancellationToken = default)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, bool includePreliminary = true, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
-			var queryParams = $"?preliminary={includePreliminary}";
-			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Reviews, queryParams };
+			var endpointParts = new List<string>() {JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Reviews};
+			
+			// If false explicitly passed, it will return nothing back. Must be added dynamically as if api has reviews/ it will also error out
+			if (includePreliminary)
+			{
+				endpointParts.Add("?preliminary=true");
+			}
 			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 

--- a/JikanDotNet/Jikan.cs
+++ b/JikanDotNet/Jikan.cs
@@ -459,10 +459,11 @@ namespace JikanDotNet
 		}
 
 		/// <inheritdoc />
-		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, CancellationToken cancellationToken = default)
+		public async Task<PaginatedJikanResponse<ICollection<Review>>> GetMangaReviewsAsync(long id, bool includePreliminary = false, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
-			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Reviews };
+			var queryParams = $"?preliminary={includePreliminary}";
+			var endpointParts = new[] { JikanEndpointConsts.Manga, id.ToString(), JikanEndpointConsts.Reviews, queryParams };
 			return await ExecuteGetRequestAsync<PaginatedJikanResponse<ICollection<Review>>>(endpointParts, cancellationToken);
 		}
 

--- a/JikanDotNet/Jikan.cs
+++ b/JikanDotNet/Jikan.cs
@@ -71,7 +71,7 @@ namespace JikanDotNet
         private async Task<T> ExecuteGetRequestAsync<T>(ICollection<string> routeSections, CancellationToken cancellationToken = default) where T : class
 		{
 			T returnedObject = null;
-			var requestUrl = string.Join("/", routeSections);
+			var requestUrl = string.Join("/", routeSections).Replace("/?", "?");
 			try
 			{
 				using var response = await _limiter.LimitAsync(() => _httpClient.GetAsync(requestUrl, cancellationToken));


### PR DESCRIPTION
MAL by default does not include Preliminary reviews, which makes the API respond differently from the website. This change allows the API to fetch the correct information from MAL. 

See https://github.com/jikan-me/jikan-rest/issues/407

After testing, I opted to leave it as true by default. If left on false, existing tests will break. This ensures that the functionality matches what was there prior to MAL adding Preliminary reviews. 