### PR TITLE
Fix some of the Jikan entries not working

### DIFF
--- a/JikanDotNet/Helpers/DefaultHttpClientProvider.cs
+++ b/JikanDotNet/Helpers/DefaultHttpClientProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace JikanDotNet.Helpers
 {
@@ -23,11 +25,25 @@ namespace JikanDotNet.Helpers
 		{
 			var uriEndpoint = !string.IsNullOrWhiteSpace(endpoint) ? endpoint : DefaultEndpoint;
 			
-			var client = new HttpClient() {BaseAddress = new Uri(uriEndpoint)};
+			var client = new HttpClient(new ForceHttp11Handler(new HttpClientHandler())) {BaseAddress = new Uri(uriEndpoint)};
 			client.DefaultRequestHeaders.Accept.Clear();
 			client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
-			
-			return client;
+
+            client.DefaultRequestHeaders.AcceptEncoding.Clear();
+            client.DefaultRequestHeaders.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate, br, zstd");
+
+            return client;
 		}
-	}
+
+        internal class ForceHttp11Handler : DelegatingHandler
+        {
+            public ForceHttp11Handler(HttpMessageHandler innerHandler) : base(innerHandler) { }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                request.Version = new Version(1, 1);
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+    }
 }

--- a/JikanDotNet/Helpers/DefaultHttpClientProvider.cs
+++ b/JikanDotNet/Helpers/DefaultHttpClientProvider.cs
@@ -29,12 +29,19 @@ namespace JikanDotNet.Helpers
 			client.DefaultRequestHeaders.Accept.Clear();
 			client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
 
+			//This exact value (also order) of Accept-Encoding makes Jikan accept way more requests from my testing.
+			//Decryption handling for gzip and deflate was also added to Jikan.cs.
+			//Jikan never returns anything other than gzip from my testing.
             client.DefaultRequestHeaders.AcceptEncoding.Clear();
             client.DefaultRequestHeaders.TryAddWithoutValidation("Accept-Encoding", "gzip, deflate, br, zstd");
 
             return client;
 		}
 
+		/// <summary>
+		/// Handler that ensures every request uses HTTP/1.1 since Jikan doesn't support HTTP/2.0, 
+		/// and some HttpClients, like the one from Xamarin used by MALClient, automatically sends HTTP/2.0
+		/// </summary>
         internal class ForceHttp11Handler : DelegatingHandler
         {
             public ForceHttp11Handler(HttpMessageHandler innerHandler) : base(innerHandler) { }

--- a/JikanDotNet/Jikan.cs
+++ b/JikanDotNet/Jikan.cs
@@ -100,6 +100,12 @@ namespace JikanDotNet
 			return returnedObject;
 		}
 
+        /// <summary>
+        /// Decompresses a HttpResponseMessage response with gzip, deflate.
+        /// Also supports br if NET6 or greater is used (so not netstandard2.0).
+        /// </summary>
+        /// <param name="response"></param> response to be decompressed
+        /// <returns></returns>
         private static async Task<string> ReadDecompressedStringAsync(HttpResponseMessage response)
         {
             var stream = await response.Content.ReadAsStreamAsync();

--- a/JikanDotNet/Jikan.cs
+++ b/JikanDotNet/Jikan.cs
@@ -6,6 +6,8 @@ using JikanDotNet.Helpers;
 using JikanDotNet.Limiter;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
@@ -77,13 +79,13 @@ namespace JikanDotNet
 				using var response = await _limiter.LimitAsync(() => _httpClient.GetAsync(requestUrl, cancellationToken));
 				if (response.IsSuccessStatusCode)
 				{
-					var json = await response.Content.ReadAsStringAsync();
+					var json = await ReadDecompressedStringAsync(response);
 
 					returnedObject = JsonSerializer.Deserialize<T>(json);
 				}
 				else if (!_jikanConfiguration.SuppressException)
 				{
-					var json = await response.Content.ReadAsStringAsync();
+					var json = await ReadDecompressedStringAsync(response);
 					var errorData = JsonSerializer.Deserialize<JikanApiError>(json);
 					throw new JikanRequestException(string.Format(ErrorMessagesConst.FailedRequest, response.StatusCode, response.Content), errorData);
 				}
@@ -98,14 +100,45 @@ namespace JikanDotNet
 			return returnedObject;
 		}
 
+        private static async Task<string> ReadDecompressedStringAsync(HttpResponseMessage response)
+        {
+            var stream = await response.Content.ReadAsStreamAsync();
+            var encoding = response.Content.Headers.ContentEncoding;
+
+            if (encoding.Contains("gzip"))
+            {
+                using var gzip = new GZipStream(stream, CompressionMode.Decompress);
+                using var reader = new StreamReader(gzip);
+                return await reader.ReadToEndAsync();
+            }
+            if (encoding.Contains("deflate"))
+            {
+                using var deflate = new DeflateStream(stream, CompressionMode.Decompress);
+                using var reader = new StreamReader(deflate);
+                return await reader.ReadToEndAsync();
+            }
+#if NET6_0_OR_GREATER
+            if (encoding.Contains("br"))
+            {
+                using var brotli = new BrotliStream(stream, CompressionMode.Decompress);
+                using var reader = new StreamReader(brotli);
+                return await reader.ReadToEndAsync();
+            }
+#endif
+
+            // no encoding, or something unsupported (e.g. br/zstd) — read as-is
+            using var plainReader = new StreamReader(stream);
+            return await plainReader.ReadToEndAsync();
+        }
+
         #endregion Private Methods
 
-		#region Public Methods
+        #region Public Methods
 
-		#region Anime methods
+        #region Anime methods
 
-		/// <inheritdoc />
-		public async Task<BaseJikanResponse<Anime>> GetAnimeAsync(long id, CancellationToken cancellationToken = default)
+        /// <inheritdoc />
+        public async Task<BaseJikanResponse<Anime>> GetAnimeAsync(long id, CancellationToken cancellationToken = default)
 		{
 			Guard.IsGreaterThanZero(id, nameof(id));
 			var endpointParts = new[] { JikanEndpointConsts.Anime, id.ToString() };


### PR DESCRIPTION
The Jikan api has been having issues for a few days now, and I found some improvements that makes entries work that didn't work before.

For example:
`GET https://api.jikan.moe/v4/anime/38671` returns a `504 {"status":504,"type":"BadResponseException","message":"Jikan failed to connect to MyAnimeList. MyAnimeList may be down\\/unavailable or refuses to connect","error":null}`

However,
`GET https://api.jikan.moe/v4/anime/38671` with `Accept-Encoding: gzip, deflate, br, zstd` returns a 200 with a valid response.

After further testing, it is only this exact `Accept-Encoding` string that works. Changing the order or removing one of the encodings causes a `504` again.

Furthermore, some projects, like [MALClient](https://github.com/Drutol/MALClient) use Xamarin that automatically use `HTTP/2.0`, however Jikan doesn't support `HTTP/2.0`. That's why I also added an intercepter that forced requests to use `HTTP/1.1`, regardless of the used `HttpClient`

In my testing, these fixes caused 9/10 requests that failed before to work again, however still not all work. However, for now this makes the library a lot more usable again :)